### PR TITLE
[EDU-162] 상태별 문제 셋 목록 조회

### DIFF
--- a/src/main/java/com/coniv/mait/domain/question/enums/DeliveryMode.java
+++ b/src/main/java/com/coniv/mait/domain/question/enums/DeliveryMode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum DeliveryMode {
+	MAKING("문제 제작"),
 	LIVE_TIME("실시간"),
 	REVIEW("복습");
 

--- a/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetEntityRepository.java
+++ b/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetEntityRepository.java
@@ -5,7 +5,10 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
+import com.coniv.mait.domain.question.enums.DeliveryMode;
 
 public interface QuestionSetEntityRepository extends JpaRepository<QuestionSetEntity, Long> {
 	List<QuestionSetEntity> findAllByTeamId(Long teamId);
+
+	List<QuestionSetEntity> findAllByTeamIdAndDeliveryMode(Long teamId, DeliveryMode deliveryMode);
 }

--- a/src/main/java/com/coniv/mait/domain/question/service/QuestionSetService.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/QuestionSetService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
+import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
@@ -35,11 +36,12 @@ public class QuestionSetService {
 			.build();
 	}
 
-	public List<QuestionSetDto> getQuestionSets(final Long teamId) {
+	public List<QuestionSetDto> getQuestionSets(final Long teamId, final DeliveryMode mode) {
 		// Todo: 조회하려는 유저와 팀이 일치하는지 확인
-		return questionSetEntityRepository.findAllByTeamId(teamId).stream()
+
+		return questionSetEntityRepository.findAllByTeamIdAndDeliveryMode(teamId, mode).stream()
 			.sorted(Comparator.comparing(
-				QuestionSetEntity::getCreatedAt,
+				QuestionSetEntity::getModifiedAt,
 				Comparator.nullsLast(Comparator.naturalOrder())
 			).reversed())
 			.map(QuestionSetDto::from)

--- a/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetDto.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetDto.java
@@ -25,7 +25,7 @@ public class QuestionSetDto {
 	private DeliveryMode deliveryMode;
 	private Long teamId;
 	private Long questionCount;
-	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 
 	public static QuestionSetDto from(final QuestionSetEntity questionSetEntity) {
 		return QuestionSetDto.builder()
@@ -36,7 +36,7 @@ public class QuestionSetDto {
 			.visibility(questionSetEntity.getVisibility())
 			.deliveryMode(questionSetEntity.getDeliveryMode())
 			.teamId(questionSetEntity.getTeamId())
-			.createdAt(questionSetEntity.getCreatedAt())
+			.updatedAt(questionSetEntity.getModifiedAt())
 			.build();
 	}
 
@@ -49,7 +49,7 @@ public class QuestionSetDto {
 			.visibility(questionSetEntity.getVisibility())
 			.deliveryMode(questionSetEntity.getDeliveryMode())
 			.teamId(questionSetEntity.getTeamId())
-			.createdAt(questionSetEntity.getCreatedAt())
+			.updatedAt(questionSetEntity.getModifiedAt())
 			.questionCount(questionCount)
 			.build();
 	}

--- a/src/main/java/com/coniv/mait/web/question/controller/QuestionSetController.java
+++ b/src/main/java/com/coniv/mait/web/question/controller/QuestionSetController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.service.QuestionSetService;
 import com.coniv.mait.domain.question.service.dto.QuestionSetDto;
 import com.coniv.mait.global.response.ApiResponse;
@@ -44,8 +45,9 @@ public class QuestionSetController {
 	@Operation(summary = "문제 셋 목록 조회")
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<QuestionSetApiResponse>>> getQuestionSets(
+		@RequestParam(value = "mode") DeliveryMode mode,
 		@RequestParam("teamId") Long teamId) {
-		List<QuestionSetApiResponse> responses = questionSetService.getQuestionSets(teamId)
+		List<QuestionSetApiResponse> responses = questionSetService.getQuestionSets(teamId, mode)
 			.stream()
 			.map(QuestionSetApiResponse::from)
 			.toList();

--- a/src/main/java/com/coniv/mait/web/question/dto/QuestionSetApiResponse.java
+++ b/src/main/java/com/coniv/mait/web/question/dto/QuestionSetApiResponse.java
@@ -28,7 +28,7 @@ public record QuestionSetApiResponse(
 	@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
 	Long questionCount,
 	@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-	LocalDateTime createdAt
+	LocalDateTime updatedAt
 
 ) {
 	public static QuestionSetApiResponse from(final QuestionSetDto questionSetDto) {
@@ -41,7 +41,7 @@ public record QuestionSetApiResponse(
 			.deliveryMode(questionSetDto.getDeliveryMode())
 			.teamId(questionSetDto.getTeamId())
 			.questionCount(questionSetDto.getQuestionCount())
-			.createdAt(questionSetDto.getCreatedAt())
+			.updatedAt(questionSetDto.getUpdatedAt())
 			.build();
 	}
 }

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
@@ -62,8 +62,8 @@ class QuestionSetServiceTest {
 
 		when(older.getId()).thenReturn(1L);
 		when(newer.getId()).thenReturn(2L);
-		when(older.getCreatedAt()).thenReturn(now.minusDays(1));
-		when(newer.getCreatedAt()).thenReturn(now.plusDays(1));
+		when(older.getModifiedAt()).thenReturn(now.minusDays(1));
+		when(newer.getModifiedAt()).thenReturn(now.plusDays(1));
 
 		when(questionSetEntityRepository.findAllByTeamIdAndDeliveryMode(teamId, mode))
 			.thenReturn(List.of(older, newer));

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
+import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
@@ -55,6 +56,7 @@ class QuestionSetServiceTest {
 		// given
 		final Long teamId = 1L;
 		final LocalDateTime now = LocalDateTime.now();
+		final DeliveryMode mode = DeliveryMode.LIVE_TIME;
 		QuestionSetEntity older = mock(QuestionSetEntity.class);
 		QuestionSetEntity newer = mock(QuestionSetEntity.class);
 
@@ -63,18 +65,18 @@ class QuestionSetServiceTest {
 		when(older.getCreatedAt()).thenReturn(now.minusDays(1));
 		when(newer.getCreatedAt()).thenReturn(now.plusDays(1));
 
-		when(questionSetEntityRepository.findAllByTeamId(teamId))
+		when(questionSetEntityRepository.findAllByTeamIdAndDeliveryMode(teamId, mode))
 			.thenReturn(List.of(older, newer));
 
 		// when
-		List<QuestionSetDto> result = questionSetService.getQuestionSets(teamId);
+		List<QuestionSetDto> result = questionSetService.getQuestionSets(teamId, mode);
 
 		// then
 		assertThat(result).hasSize(2);
 		assertThat(result.get(0).getId()).isEqualTo(2L); // 최신 것이 먼저
 		assertThat(result.get(1).getId()).isEqualTo(1L);
 
-		verify(questionSetEntityRepository, times(1)).findAllByTeamId(teamId);
+		verify(questionSetEntityRepository, times(1)).findAllByTeamIdAndDeliveryMode(teamId, mode);
 	}
 
 	@Test

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
@@ -64,8 +64,16 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 		String subject2 = "Subject 2";
 		final DeliveryMode deliveryMode = DeliveryMode.LIVE_TIME;
 
-		QuestionSetEntity questionSet1 = QuestionSetEntity.builder().subject(subject1).teamId(team.getId()).deliveryMode(deliveryMode).build();
-		QuestionSetEntity questionSet2 = QuestionSetEntity.builder().subject(subject2).teamId(team.getId()).deliveryMode(deliveryMode).build();
+		QuestionSetEntity questionSet1 = QuestionSetEntity.builder()
+			.subject(subject1)
+			.teamId(team.getId())
+			.deliveryMode(deliveryMode)
+			.build();
+		QuestionSetEntity questionSet2 = QuestionSetEntity.builder()
+			.subject(subject2)
+			.teamId(team.getId())
+			.deliveryMode(deliveryMode)
+			.build();
 
 		questionSetEntityRepository.save(questionSet1);
 		questionSetEntityRepository.save(questionSet2);

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
@@ -71,6 +71,7 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 		// when
 		mockMvc.perform(get("/api/v1/question-sets")
 				.param("teamId", String.valueOf(team.getId()))
+				.param("mode", "LIVE_TIME")
 				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.length()").value(2))

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
+import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
 import com.coniv.mait.domain.team.entity.TeamEntity;
@@ -61,9 +62,10 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 		TeamEntity team = teamEntityRepository.save(TeamEntity.builder().name("코니브").build());
 		String subject1 = "Subject 1";
 		String subject2 = "Subject 2";
+		final DeliveryMode deliveryMode = DeliveryMode.LIVE_TIME;
 
-		QuestionSetEntity questionSet1 = QuestionSetEntity.builder().subject(subject1).teamId(team.getId()).build();
-		QuestionSetEntity questionSet2 = QuestionSetEntity.builder().subject(subject2).teamId(team.getId()).build();
+		QuestionSetEntity questionSet1 = QuestionSetEntity.builder().subject(subject1).teamId(team.getId()).deliveryMode(deliveryMode).build();
+		QuestionSetEntity questionSet2 = QuestionSetEntity.builder().subject(subject2).teamId(team.getId()).deliveryMode(deliveryMode).build();
 
 		questionSetEntityRepository.save(questionSet1);
 		questionSetEntityRepository.save(questionSet2);
@@ -71,7 +73,7 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 		// when
 		mockMvc.perform(get("/api/v1/question-sets")
 				.param("teamId", String.valueOf(team.getId()))
-				.param("mode", "LIVE_TIME")
+				.param("mode", deliveryMode.name())
 				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.length()").value(2))

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
@@ -149,7 +149,8 @@ class QuestionSetControllerTest {
 		QuestionSetDto questionSet1 = QuestionSetDto.builder().id(1L).subject("Subject 1").build();
 		QuestionSetDto questionSet2 = QuestionSetDto.builder().id(2L).subject("Subject 2").build();
 		final DeliveryMode mode = DeliveryMode.LIVE_TIME;
-		when(questionSetService.getQuestionSets(teamId, DeliveryMode.LIVE_TIME)).thenReturn(List.of(questionSet1, questionSet2));
+		when(questionSetService.getQuestionSets(teamId, DeliveryMode.LIVE_TIME)).thenReturn(
+			List.of(questionSet1, questionSet2));
 
 		// when & then
 		mockMvc.perform(get("/api/v1/question-sets")

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.service.QuestionSetService;
 import com.coniv.mait.domain.question.service.dto.QuestionSetDto;
@@ -147,11 +148,13 @@ class QuestionSetControllerTest {
 		Long teamId = 1L;
 		QuestionSetDto questionSet1 = QuestionSetDto.builder().id(1L).subject("Subject 1").build();
 		QuestionSetDto questionSet2 = QuestionSetDto.builder().id(2L).subject("Subject 2").build();
-		when(questionSetService.getQuestionSets(teamId, null)).thenReturn(List.of(questionSet1, questionSet2));
+		final DeliveryMode mode = DeliveryMode.LIVE_TIME;
+		when(questionSetService.getQuestionSets(teamId, DeliveryMode.LIVE_TIME)).thenReturn(List.of(questionSet1, questionSet2));
 
 		// when & then
 		mockMvc.perform(get("/api/v1/question-sets")
-				.param("teamId", String.valueOf(teamId)))
+				.param("teamId", String.valueOf(teamId))
+				.param("mode", mode.name()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.length()").value(2))
 			.andExpect(jsonPath("$.data[0].id").value(1L))
@@ -159,7 +162,7 @@ class QuestionSetControllerTest {
 			.andExpect(jsonPath("$.data[1].id").value(2L))
 			.andExpect(jsonPath("$.data[1].subject").value("Subject 2"));
 
-		verify(questionSetService).getQuestionSets(teamId, null);
+		verify(questionSetService).getQuestionSets(teamId, mode);
 	}
 
 	@Test

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
@@ -147,7 +147,7 @@ class QuestionSetControllerTest {
 		Long teamId = 1L;
 		QuestionSetDto questionSet1 = QuestionSetDto.builder().id(1L).subject("Subject 1").build();
 		QuestionSetDto questionSet2 = QuestionSetDto.builder().id(2L).subject("Subject 2").build();
-		when(questionSetService.getQuestionSets(teamId)).thenReturn(List.of(questionSet1, questionSet2));
+		when(questionSetService.getQuestionSets(teamId, null)).thenReturn(List.of(questionSet1, questionSet2));
 
 		// when & then
 		mockMvc.perform(get("/api/v1/question-sets")
@@ -159,7 +159,7 @@ class QuestionSetControllerTest {
 			.andExpect(jsonPath("$.data[1].id").value(2L))
 			.andExpect(jsonPath("$.data[1].subject").value("Subject 2"));
 
-		verify(questionSetService).getQuestionSets(teamId);
+		verify(questionSetService).getQuestionSets(teamId, null);
 	}
 
 	@Test


### PR DESCRIPTION
### Motivation

<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

문제 셋 목록 조회를 '제작 중', '실시간', '복습' 과 같은 상태별로 조회할 수 있어야한다.

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

타입 추가

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)

<!-- 테스트 결과를 보여주세요. -->

### SQL

<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->

제작중이 들어가서 상태값 필드명이 delivery_mode인게 애매한데 필드명 바꿀까요?
