### PR TITLE
[EDU-501] 삭제된 카테고리 복구 API

### DIFF
--- a/src/main/java/com/coniv/mait/domain/question/exception/code/QuestionSetCategoryExceptionCode.java
+++ b/src/main/java/com/coniv/mait/domain/question/exception/code/QuestionSetCategoryExceptionCode.java
@@ -12,7 +12,8 @@ import lombok.RequiredArgsConstructor;
 public enum QuestionSetCategoryExceptionCode implements ExceptionCode {
 
 	DUPLICATE_NAME(HttpStatus.CONFLICT, "QSC-001", "이미 존재하는 카테고리입니다."),
-	DUPLICATE_NAME_DELETED(HttpStatus.CONFLICT, "QSC-002", "삭제된 동일 이름의 카테고리가 존재합니다. 복구하시겠습니까?");
+	DUPLICATE_NAME_DELETED(HttpStatus.CONFLICT, "QSC-002", "삭제된 동일 이름의 카테고리가 존재합니다. 복구하시겠습니까?"),
+	ALREADY_ACTIVE(HttpStatus.CONFLICT, "QSC-003", "이미 활성 상태인 카테고리입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetCategoryEntityRepository.java
+++ b/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetCategoryEntityRepository.java
@@ -1,6 +1,7 @@
 package com.coniv.mait.domain.question.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,6 +12,8 @@ public interface QuestionSetCategoryEntityRepository extends JpaRepository<Quest
 	boolean existsByTeamIdAndNameAndDeletedAtIsNull(Long teamId, String name);
 
 	boolean existsByTeamIdAndNameAndDeletedAtIsNotNull(Long teamId, String name);
+
+	Optional<QuestionSetCategoryEntity> findByTeamIdAndNameAndDeletedAtIsNotNull(Long teamId, String name);
 
 	List<QuestionSetCategoryEntity> findAllByTeamIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long teamId);
 }

--- a/src/main/java/com/coniv/mait/domain/question/service/QuestionSetCategoryService.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/QuestionSetCategoryService.java
@@ -62,4 +62,20 @@ public class QuestionSetCategoryService {
 
 		category.markDeleted();
 	}
+
+	@Transactional
+	public QuestionSetCategoryDto restoreCategory(final Long teamId, final String name, final Long userId) {
+		teamRoleValidator.checkHasCreateQuestionSetAuthority(teamId, userId);
+
+		if (questionSetCategoryEntityRepository.existsByTeamIdAndNameAndDeletedAtIsNull(teamId, name)) {
+			throw new QuestionSetCategoryException(QuestionSetCategoryExceptionCode.ALREADY_ACTIVE);
+		}
+
+		QuestionSetCategoryEntity category = questionSetCategoryEntityRepository
+			.findByTeamIdAndNameAndDeletedAtIsNotNull(teamId, name)
+			.orElseThrow(() -> new EntityNotFoundException("복구할 카테고리를 찾을 수 없습니다."));
+
+		category.restore();
+		return QuestionSetCategoryDto.from(category);
+	}
 }

--- a/src/main/java/com/coniv/mait/web/question/controller/QuestionSetCategoryController.java
+++ b/src/main/java/com/coniv/mait/web/question/controller/QuestionSetCategoryController.java
@@ -19,6 +19,7 @@ import com.coniv.mait.global.auth.model.MaitUser;
 import com.coniv.mait.global.response.ApiResponse;
 import com.coniv.mait.web.question.dto.CreateQuestionSetCategoryApiRequest;
 import com.coniv.mait.web.question.dto.QuestionSetCategoryApiResponse;
+import com.coniv.mait.web.question.dto.RestoreQuestionSetCategoryApiRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -59,5 +60,15 @@ public class QuestionSetCategoryController {
 		@AuthenticationPrincipal MaitUser user, @PathVariable Long categoryId) {
 		questionSetCategoryService.deleteCategory(categoryId, user.id());
 		return ResponseEntity.ok(ApiResponse.noContent());
+	}
+
+	@Operation(summary = "문제 셋 카테고리 복구 API",
+		description = "팀과 이름으로 식별되는 soft delete 된 카테고리를 복구합니다. 동일 이름 활성 카테고리가 존재하면 409 를 반환합니다.")
+	@PostMapping("/restore")
+	public ResponseEntity<ApiResponse<QuestionSetCategoryApiResponse>> restoreCategory(
+		@AuthenticationPrincipal MaitUser user, @Valid @RequestBody RestoreQuestionSetCategoryApiRequest request) {
+		QuestionSetCategoryDto category = questionSetCategoryService.restoreCategory(
+			request.teamId(), request.name(), user.id());
+		return ResponseEntity.ok(ApiResponse.ok(QuestionSetCategoryApiResponse.from(category)));
 	}
 }

--- a/src/main/java/com/coniv/mait/web/question/dto/RestoreQuestionSetCategoryApiRequest.java
+++ b/src/main/java/com/coniv/mait/web/question/dto/RestoreQuestionSetCategoryApiRequest.java
@@ -1,0 +1,14 @@
+package com.coniv.mait.web.question.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RestoreQuestionSetCategoryApiRequest(
+	@NotNull(message = "팀 정보는 필수 입니다.")
+	Long teamId,
+	@NotBlank(message = "카테고리 이름을 입력해주세요.")
+	@Size(max = 40, message = "카테고리 이름은 40자 이하여야 합니다.")
+	String name
+) {
+}

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetCategoryServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetCategoryServiceTest.java
@@ -242,4 +242,91 @@ class QuestionSetCategoryServiceTest {
 
 		assertThat(category.deleted()).isFalse();
 	}
+
+	@Test
+	@DisplayName("카테고리 복구 성공 - 삭제된 카테고리의 deletedAt 이 null 로 변경됨")
+	void restoreCategory_success() {
+		// given
+		Long teamId = 1L;
+		Long userId = 10L;
+		String name = "알고리즘";
+
+		QuestionSetCategoryEntity category = QuestionSetCategoryEntity.of(teamId, name);
+		category.markDeleted();
+		when(questionSetCategoryEntityRepository.existsByTeamIdAndNameAndDeletedAtIsNull(teamId, name))
+			.thenReturn(false);
+		when(questionSetCategoryEntityRepository.findByTeamIdAndNameAndDeletedAtIsNotNull(teamId, name))
+			.thenReturn(Optional.of(category));
+
+		// when
+		QuestionSetCategoryDto result = questionSetCategoryService.restoreCategory(teamId, name, userId);
+
+		// then
+		assertThat(category.deleted()).isFalse();
+		assertThat(result.getTeamId()).isEqualTo(teamId);
+		assertThat(result.getName()).isEqualTo(name);
+
+		verify(teamRoleValidator).checkHasCreateQuestionSetAuthority(teamId, userId);
+	}
+
+	@Test
+	@DisplayName("카테고리 복구 실패 - 권한 없음 (TeamRoleValidator 예외 전파)")
+	void restoreCategory_fail_noPermission() {
+		// given
+		Long teamId = 1L;
+		Long userId = 10L;
+		String name = "알고리즘";
+
+		doThrow(new RuntimeException("권한 없음"))
+			.when(teamRoleValidator).checkHasCreateQuestionSetAuthority(teamId, userId);
+
+		// when & then
+		assertThatThrownBy(() -> questionSetCategoryService.restoreCategory(teamId, name, userId))
+			.isInstanceOf(RuntimeException.class);
+
+		verify(questionSetCategoryEntityRepository, never())
+			.existsByTeamIdAndNameAndDeletedAtIsNull(anyLong(), anyString());
+		verify(questionSetCategoryEntityRepository, never())
+			.findByTeamIdAndNameAndDeletedAtIsNotNull(anyLong(), anyString());
+	}
+
+	@Test
+	@DisplayName("카테고리 복구 실패 - 동일 이름의 활성 카테고리가 이미 존재")
+	void restoreCategory_fail_alreadyActive() {
+		// given
+		Long teamId = 1L;
+		Long userId = 10L;
+		String name = "알고리즘";
+
+		when(questionSetCategoryEntityRepository.existsByTeamIdAndNameAndDeletedAtIsNull(teamId, name))
+			.thenReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> questionSetCategoryService.restoreCategory(teamId, name, userId))
+			.isInstanceOf(QuestionSetCategoryException.class)
+			.extracting("exceptionCode")
+			.isEqualTo(QuestionSetCategoryExceptionCode.ALREADY_ACTIVE);
+
+		verify(questionSetCategoryEntityRepository, never())
+			.findByTeamIdAndNameAndDeletedAtIsNotNull(anyLong(), anyString());
+	}
+
+	@Test
+	@DisplayName("카테고리 복구 실패 - 복구할 카테고리가 존재하지 않음")
+	void restoreCategory_fail_notFound() {
+		// given
+		Long teamId = 1L;
+		Long userId = 10L;
+		String name = "알고리즘";
+
+		when(questionSetCategoryEntityRepository.existsByTeamIdAndNameAndDeletedAtIsNull(teamId, name))
+			.thenReturn(false);
+		when(questionSetCategoryEntityRepository.findByTeamIdAndNameAndDeletedAtIsNotNull(teamId, name))
+			.thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> questionSetCategoryService.restoreCategory(teamId, name, userId))
+			.isInstanceOf(EntityNotFoundException.class)
+			.hasMessageContaining("복구할 카테고리를 찾을 수 없습니다.");
+	}
 }

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetCategoryApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetCategoryApiIntegrationTest.java
@@ -24,6 +24,7 @@ import com.coniv.mait.domain.user.repository.UserEntityRepository;
 import com.coniv.mait.login.WithCustomUser;
 import com.coniv.mait.web.integration.BaseIntegrationTest;
 import com.coniv.mait.web.question.dto.CreateQuestionSetCategoryApiRequest;
+import com.coniv.mait.web.question.dto.RestoreQuestionSetCategoryApiRequest;
 
 @WithCustomUser
 public class QuestionSetCategoryApiIntegrationTest extends BaseIntegrationTest {
@@ -90,6 +91,37 @@ public class QuestionSetCategoryApiIntegrationTest extends BaseIntegrationTest {
 			.orElseThrow();
 		assertThat(updated.deleted()).isTrue();
 		assertThat(updated.getDeletedAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("카테고리 복구 API 성공 테스트 - MAKER 권한, (teamId, name) 식별 row 의 deletedAt 이 null 로 반영")
+	void restoreCategoryApiSuccess() throws Exception {
+		// given
+		UserEntity currentUser = userEntityRepository.findByEmail("user@example.com").orElseThrow();
+		TeamEntity team = teamEntityRepository.save(TeamEntity.builder().name("코니브").creatorId(1L).build());
+		teamUserEntityRepository.save(TeamUserEntity.createTeamUser(currentUser, team, TeamUserRole.MAKER));
+
+		QuestionSetCategoryEntity category = QuestionSetCategoryEntity.of(team.getId(), "알고리즘");
+		category.updateDeletedAt(LocalDateTime.now());
+		QuestionSetCategoryEntity saved = questionSetCategoryEntityRepository.save(category);
+
+		RestoreQuestionSetCategoryApiRequest request = new RestoreQuestionSetCategoryApiRequest(
+			team.getId(), "알고리즘");
+
+		// when & then
+		mockMvc.perform(post("/api/v1/question-sets/categories/restore")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.data.id").value(saved.getId()),
+				jsonPath("$.data.teamId").value(team.getId()),
+				jsonPath("$.data.name").value("알고리즘"));
+
+		QuestionSetCategoryEntity updated = questionSetCategoryEntityRepository.findById(saved.getId())
+			.orElseThrow();
+		assertThat(updated.deleted()).isFalse();
+		assertThat(updated.getDeletedAt()).isNull();
 	}
 
 	@Test

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetCategoryControllerTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetCategoryControllerTest.java
@@ -30,6 +30,7 @@ import com.coniv.mait.global.auth.model.MaitUser;
 import com.coniv.mait.global.filter.JwtAuthorizationFilter;
 import com.coniv.mait.global.interceptor.idempotency.IdempotencyInterceptor;
 import com.coniv.mait.web.question.dto.CreateQuestionSetCategoryApiRequest;
+import com.coniv.mait.web.question.dto.RestoreQuestionSetCategoryApiRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = QuestionSetCategoryController.class)
@@ -141,6 +142,65 @@ class QuestionSetCategoryControllerTest {
 				jsonPath("$.isSuccess").value(true));
 
 		verify(questionSetCategoryService).deleteCategory(categoryId, USER_ID);
+	}
+
+	@Test
+	@DisplayName("카테고리 복구 성공 - 200 OK 와 응답 바디 반환")
+	void restoreCategorySuccess() throws Exception {
+		// given
+		Long categoryId = 100L;
+		Long teamId = 1L;
+		String name = "알고리즘";
+
+		RestoreQuestionSetCategoryApiRequest request = new RestoreQuestionSetCategoryApiRequest(teamId, name);
+		QuestionSetCategoryDto dto = QuestionSetCategoryDto.builder()
+			.id(categoryId)
+			.teamId(teamId)
+			.name(name)
+			.build();
+
+		when(questionSetCategoryService.restoreCategory(teamId, name, USER_ID)).thenReturn(dto);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/question-sets/categories/restore")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.data.id").value(categoryId),
+				jsonPath("$.data.teamId").value(teamId),
+				jsonPath("$.data.name").value(name));
+
+		verify(questionSetCategoryService).restoreCategory(teamId, name, USER_ID);
+	}
+
+	@ParameterizedTest(name = "{index} - {0}")
+	@DisplayName("카테고리 복구 실패 - 유효하지 않은 요청 (400)")
+	@MethodSource("invalidRestoreCategoryRequests")
+	void restoreCategoryInvalidRequest(String testName, Long teamId, String name, String expectedReason)
+		throws Exception {
+		// given
+		RestoreQuestionSetCategoryApiRequest request = new RestoreQuestionSetCategoryApiRequest(teamId, name);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/question-sets/categories/restore")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpectAll(
+				status().isBadRequest(),
+				jsonPath("$.isSuccess").value(false),
+				jsonPath("$.reasons[*]").value(org.hamcrest.Matchers.hasItem(expectedReason)));
+
+		verify(questionSetCategoryService, never()).restoreCategory(any(), any(), any());
+	}
+
+	static Stream<Arguments> invalidRestoreCategoryRequests() {
+		return Stream.of(
+			Arguments.of("teamId null", null, "알고리즘", "팀 정보는 필수 입니다."),
+			Arguments.of("name 빈 문자열", 1L, "", "카테고리 이름을 입력해주세요."),
+			Arguments.of("name null", 1L, null, "카테고리 이름을 입력해주세요."),
+			Arguments.of("name 공백", 1L, "   ", "카테고리 이름을 입력해주세요."),
+			Arguments.of("name 41자 초과", 1L, "가".repeat(41), "카테고리 이름은 40자 이하여야 합니다."));
 	}
 
 	@Test


### PR DESCRIPTION
### Motivation

<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

삭제된 카테고리 이름을 다시 생성하려고 하면 유저의 확인을 받은 이후 복구를 할 수 있다.

기존에 팀에 존재하던 

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

사용자는 기존 PK를 모르기에 teamId, name을 기반으로 생성한다.

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)

<!-- 테스트 결과를 보여주세요. -->

- [x] 단위테스트를 작성했는지
- [x] 컨트롤러 단위테스트를 작성했는지
- [x] 통합테스트를 작성했는지

### SQL

<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->

```sql

```
