### PR TITLE
[EDU-495] 문제 셋 카테고리 추가 API

### DIFF
--- a/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetCategoryLinkEntity.java
+++ b/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetCategoryLinkEntity.java
@@ -1,0 +1,53 @@
+package com.coniv.mait.domain.question.entity;
+
+import com.coniv.mait.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(
+	name = "question_set_category_links",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_question_set_category_links_set_category",
+			columnNames = {"question_set_id", "category_id"})
+	},
+	indexes = {
+		@Index(name = "idx_question_set_category_links_category_set",
+			columnList = "category_id, question_set_id")
+	}
+)
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionSetCategoryLinkEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "question_set_id", nullable = false)
+	private Long questionSetId;
+
+	@Column(name = "category_id", nullable = false)
+	private Long categoryId;
+
+	private QuestionSetCategoryLinkEntity(final Long questionSetId, final Long categoryId) {
+		this.questionSetId = questionSetId;
+		this.categoryId = categoryId;
+	}
+
+	public static QuestionSetCategoryLinkEntity of(final Long questionSetId, final Long categoryId) {
+		return new QuestionSetCategoryLinkEntity(questionSetId, categoryId);
+	}
+}

--- a/src/main/java/com/coniv/mait/domain/question/exception/code/QuestionSetCategoryExceptionCode.java
+++ b/src/main/java/com/coniv/mait/domain/question/exception/code/QuestionSetCategoryExceptionCode.java
@@ -13,7 +13,8 @@ public enum QuestionSetCategoryExceptionCode implements ExceptionCode {
 
 	DUPLICATE_NAME(HttpStatus.CONFLICT, "QSC-001", "이미 존재하는 카테고리입니다."),
 	DUPLICATE_NAME_DELETED(HttpStatus.CONFLICT, "QSC-002", "삭제된 동일 이름의 카테고리가 존재합니다. 복구하시겠습니까?"),
-	ALREADY_ACTIVE(HttpStatus.CONFLICT, "QSC-003", "이미 활성 상태인 카테고리입니다.");
+	ALREADY_ACTIVE(HttpStatus.CONFLICT, "QSC-003", "이미 활성 상태인 카테고리입니다."),
+	INVALID_TEAM_OR_NOT_FOUND(HttpStatus.BAD_REQUEST, "QSC-004", "카테고리를 찾을 수 없거나 다른 팀의 카테고리입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetCategoryEntityRepository.java
+++ b/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetCategoryEntityRepository.java
@@ -1,5 +1,6 @@
 package com.coniv.mait.domain.question.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +17,10 @@ public interface QuestionSetCategoryEntityRepository extends JpaRepository<Quest
 	Optional<QuestionSetCategoryEntity> findByTeamIdAndNameAndDeletedAtIsNotNull(Long teamId, String name);
 
 	List<QuestionSetCategoryEntity> findAllByTeamIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long teamId);
+
+	List<QuestionSetCategoryEntity> findAllByIdInAndTeamIdAndDeletedAtIsNull(Collection<Long> ids, Long teamId);
+
+	List<QuestionSetCategoryEntity> findAllByIdIn(Collection<Long> ids);
+
+	Optional<QuestionSetCategoryEntity> findByIdAndTeamIdAndDeletedAtIsNull(Long id, Long teamId);
 }

--- a/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetCategoryLinkEntityRepository.java
+++ b/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetCategoryLinkEntityRepository.java
@@ -1,0 +1,20 @@
+package com.coniv.mait.domain.question.repository;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
+
+public interface QuestionSetCategoryLinkEntityRepository
+	extends JpaRepository<QuestionSetCategoryLinkEntity, Long> {
+
+	List<QuestionSetCategoryLinkEntity> findAllByQuestionSetId(Long questionSetId);
+
+	boolean existsByQuestionSetIdAndCategoryId(Long questionSetId, Long categoryId);
+
+	@Modifying(clearAutomatically = true)
+	void deleteByQuestionSetIdAndCategoryIdIn(Long questionSetId, Collection<Long> categoryIds);
+}

--- a/src/main/java/com/coniv/mait/domain/question/service/QuestionSetCategoryService.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/QuestionSetCategoryService.java
@@ -1,14 +1,22 @@
 package com.coniv.mait.domain.question.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetEntity;
 import com.coniv.mait.domain.question.exception.QuestionSetCategoryException;
 import com.coniv.mait.domain.question.exception.code.QuestionSetCategoryExceptionCode;
 import com.coniv.mait.domain.question.repository.QuestionSetCategoryEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
 import com.coniv.mait.domain.question.service.dto.QuestionSetCategoryDto;
 import com.coniv.mait.domain.user.service.component.TeamRoleValidator;
 
@@ -20,6 +28,10 @@ import lombok.RequiredArgsConstructor;
 public class QuestionSetCategoryService {
 
 	private final QuestionSetCategoryEntityRepository questionSetCategoryEntityRepository;
+
+	private final QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
+
+	private final QuestionSetEntityRepository questionSetEntityRepository;
 
 	private final TeamRoleValidator teamRoleValidator;
 
@@ -77,5 +89,63 @@ public class QuestionSetCategoryService {
 
 		category.restore();
 		return QuestionSetCategoryDto.from(category);
+	}
+
+	@Transactional
+	public void attachCategory(final Long questionSetId, final Long categoryId, final Long userId) {
+		QuestionSetEntity questionSet = questionSetEntityRepository.findById(questionSetId)
+			.orElseThrow(() -> new EntityNotFoundException("문제 셋을 찾을 수 없습니다."));
+
+		teamRoleValidator.checkHasCreateQuestionSetAuthority(questionSet.getTeamId(), userId);
+
+		if (questionSetCategoryLinkEntityRepository.existsByQuestionSetIdAndCategoryId(questionSetId, categoryId)) {
+			return;
+		}
+
+		questionSetCategoryEntityRepository.findByIdAndTeamIdAndDeletedAtIsNull(categoryId, questionSet.getTeamId())
+			.orElseThrow(() -> new EntityNotFoundException("해당 카테고리를 찾을 수 없습니다."));
+
+		questionSetCategoryLinkEntityRepository.save(QuestionSetCategoryLinkEntity.of(questionSetId, categoryId));
+	}
+
+	@Transactional
+	public void attachCategories(final Long questionSetId, final Long teamId, final List<Long> categoryIds) {
+		if (categoryIds == null || categoryIds.isEmpty()) {
+			return;
+		}
+
+		Set<Long> uniqueIds = Set.copyOf(categoryIds);
+
+		List<QuestionSetCategoryEntity> categories =
+			questionSetCategoryEntityRepository.findAllByIdInAndTeamIdAndDeletedAtIsNull(uniqueIds, teamId);
+
+		if (categories.size() != uniqueIds.size()) {
+			throw new QuestionSetCategoryException(QuestionSetCategoryExceptionCode.INVALID_TEAM_OR_NOT_FOUND);
+		}
+
+		List<QuestionSetCategoryLinkEntity> links = uniqueIds.stream()
+			.map(catId -> QuestionSetCategoryLinkEntity.of(questionSetId, catId))
+			.toList();
+		questionSetCategoryLinkEntityRepository.saveAll(links);
+	}
+
+	public List<QuestionSetCategoryDto> getCategoriesByQuestionSetId(final Long questionSetId) {
+		List<QuestionSetCategoryLinkEntity> links =
+			questionSetCategoryLinkEntityRepository.findAllByQuestionSetId(questionSetId);
+		if (links.isEmpty()) {
+			return List.of();
+		}
+
+		Set<Long> categoryIds = links.stream()
+			.map(QuestionSetCategoryLinkEntity::getCategoryId)
+			.collect(Collectors.toSet());
+
+		Map<Long, QuestionSetCategoryEntity> categoryById = questionSetCategoryEntityRepository.findAllByIdIn(
+				categoryIds).stream()
+			.collect(Collectors.toUnmodifiableMap(QuestionSetCategoryEntity::getId, Function.identity()));
+
+		return links.stream()
+			.map(link -> QuestionSetCategoryDto.from(categoryById.get(link.getCategoryId())))
+			.toList();
 	}
 }

--- a/src/main/java/com/coniv/mait/domain/question/service/QuestionSetService.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/QuestionSetService.java
@@ -21,6 +21,7 @@ import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
 import com.coniv.mait.domain.question.service.component.QuestionChecker;
 import com.coniv.mait.domain.question.service.dto.QuestionCount;
+import com.coniv.mait.domain.question.service.dto.QuestionSetCategoryDto;
 import com.coniv.mait.domain.question.service.dto.QuestionSetDto;
 import com.coniv.mait.domain.question.service.dto.QuestionValidateDto;
 import com.coniv.mait.domain.user.service.component.TeamRoleValidator;
@@ -60,9 +61,12 @@ public class QuestionSetService {
 
 	private final RedisTemplate<String, String> redisTemplate;
 
+	private final QuestionSetCategoryService questionSetCategoryService;
+
 	@Transactional
 	public QuestionSetDto createQuestionSet(final QuestionSetDto questionSetDto, final List<QuestionCount> counts,
-		final List<MaterialDto> materials, final String instruction, final String difficulty, final Long userId) {
+		final List<MaterialDto> materials, final String instruction, final String difficulty,
+		final List<Long> categoryIds, final Long userId) {
 		teamRoleValidator.checkHasCreateQuestionSetAuthority(questionSetDto.getTeamId(), userId);
 
 		QuestionSetEntity questionSetEntity = QuestionSetEntity.builder()
@@ -89,6 +93,9 @@ public class QuestionSetService {
 				.difficulty(difficulty)
 				.build());
 		}
+
+		questionSetCategoryService.attachCategories(questionSetEntity.getId(), questionSetEntity.getTeamId(),
+			categoryIds);
 
 		return QuestionSetDto.from(questionSetEntity);
 	}
@@ -135,7 +142,10 @@ public class QuestionSetService {
 
 		long questionCount = questionEntityRepository.countByQuestionSetId(questionSetEntity.getId());
 
-		return QuestionSetDto.of(questionSetEntity, questionCount);
+		List<QuestionSetCategoryDto> categories =
+			questionSetCategoryService.getCategoriesByQuestionSetId(questionSetEntity.getId());
+
+		return QuestionSetDto.of(questionSetEntity, questionCount, categories);
 	}
 
 	@Transactional

--- a/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetCategoryDto.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetCategoryDto.java
@@ -12,12 +12,14 @@ public class QuestionSetCategoryDto {
 	private final Long id;
 	private final Long teamId;
 	private final String name;
+	private final boolean deleted;
 
 	public static QuestionSetCategoryDto from(final QuestionSetCategoryEntity entity) {
 		return QuestionSetCategoryDto.builder()
 			.id(entity.getId())
 			.teamId(entity.getTeamId())
 			.name(entity.getName())
+			.deleted(entity.deleted())
 			.build();
 	}
 }

--- a/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetDto.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetDto.java
@@ -31,9 +31,15 @@ public class QuestionSetDto {
 	private Long questionCount;
 	private String difficulty;
 	private List<MaterialDto> materials;
+	private List<QuestionSetCategoryDto> categories;
 	private LocalDateTime updatedAt;
 
 	public static QuestionSetDto from(final QuestionSetEntity questionSetEntity) {
+		return from(questionSetEntity, List.of());
+	}
+
+	public static QuestionSetDto from(final QuestionSetEntity questionSetEntity,
+		final List<QuestionSetCategoryDto> categories) {
 		return QuestionSetDto.builder()
 			.id(questionSetEntity.getId())
 			.subject(questionSetEntity.getSubject())
@@ -45,10 +51,16 @@ public class QuestionSetDto {
 			.teamId(questionSetEntity.getTeamId())
 			.difficulty(questionSetEntity.getDifficulty())
 			.updatedAt(questionSetEntity.getModifiedAt())
+			.categories(categories)
 			.build();
 	}
 
 	public static QuestionSetDto of(QuestionSetEntity questionSetEntity, long questionCount) {
+		return of(questionSetEntity, questionCount, List.of());
+	}
+
+	public static QuestionSetDto of(QuestionSetEntity questionSetEntity, long questionCount,
+		List<QuestionSetCategoryDto> categories) {
 		return QuestionSetDto.builder()
 			.id(questionSetEntity.getId())
 			.subject(questionSetEntity.getSubject())
@@ -61,6 +73,7 @@ public class QuestionSetDto {
 			.status(questionSetEntity.getStatus())
 			.updatedAt(questionSetEntity.getModifiedAt())
 			.questionCount(questionCount)
+			.categories(categories)
 			.build();
 	}
 

--- a/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetDto.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetDto.java
@@ -35,11 +35,6 @@ public class QuestionSetDto {
 	private LocalDateTime updatedAt;
 
 	public static QuestionSetDto from(final QuestionSetEntity questionSetEntity) {
-		return from(questionSetEntity, List.of());
-	}
-
-	public static QuestionSetDto from(final QuestionSetEntity questionSetEntity,
-		final List<QuestionSetCategoryDto> categories) {
 		return QuestionSetDto.builder()
 			.id(questionSetEntity.getId())
 			.subject(questionSetEntity.getSubject())
@@ -51,12 +46,8 @@ public class QuestionSetDto {
 			.teamId(questionSetEntity.getTeamId())
 			.difficulty(questionSetEntity.getDifficulty())
 			.updatedAt(questionSetEntity.getModifiedAt())
-			.categories(categories)
+			.categories(List.of())
 			.build();
-	}
-
-	public static QuestionSetDto of(QuestionSetEntity questionSetEntity, long questionCount) {
-		return of(questionSetEntity, questionCount, List.of());
 	}
 
 	public static QuestionSetDto of(QuestionSetEntity questionSetEntity, long questionCount,
@@ -76,5 +67,4 @@ public class QuestionSetDto {
 			.categories(categories)
 			.build();
 	}
-
 }

--- a/src/main/java/com/coniv/mait/web/question/controller/QuestionSetController.java
+++ b/src/main/java/com/coniv/mait/web/question/controller/QuestionSetController.java
@@ -21,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.coniv.mait.domain.question.enums.AiRequestStatus;
 import com.coniv.mait.domain.question.enums.DeliveryMode;
+import com.coniv.mait.domain.question.service.QuestionSetCategoryService;
 import com.coniv.mait.domain.question.service.QuestionSetDeleteService;
 import com.coniv.mait.domain.question.service.QuestionSetMaterialService;
 import com.coniv.mait.domain.question.service.QuestionSetService;
@@ -62,13 +63,16 @@ public class QuestionSetController {
 
 	private final QuestionSetMaterialService questionSetMaterialService;
 
+	private final QuestionSetCategoryService questionSetCategoryService;
+
 	@Operation(summary = "문제 셋 생성 API", description = "새로운 문제 셋을 생성합니다.")
 	@PostMapping
 	public ResponseEntity<ApiResponse<CreateQuestionSetApiResponse>> createQuestionSet(
 		@AuthenticationPrincipal MaitUser user,
 		@Valid @RequestBody CreateQuestionSetApiRequest request) {
 		QuestionSetDto questionSetDto = questionSetService.createQuestionSet(request.toQuestionSetDto(),
-			request.counts(), request.materials(), request.instruction(), request.difficulty(), user.id());
+			request.counts(), request.materials(), request.instruction(), request.difficulty(), request.categoryIds(),
+			user.id());
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponse.ok(CreateQuestionSetApiResponse.from(questionSetDto)));
 	}
@@ -122,11 +126,20 @@ public class QuestionSetController {
 				request.solveMode(), request.difficulty(), request.visibility()))));
 	}
 
+	@Operation(summary = "문제 셋에 카테고리 단건 매핑 추가 API",
+		description = "문제 셋에 카테고리 1개를 매핑한다. 이미 매핑된 경우 멱등 처리.")
+	@PostMapping("/{questionSetId}/categories/{categoryId}")
+	public ResponseEntity<ApiResponse<Void>> attachCategory(@PathVariable Long questionSetId,
+		@PathVariable Long categoryId, @AuthenticationPrincipal MaitUser user) {
+		questionSetCategoryService.attachCategory(questionSetId, categoryId, user.id());
+		return ResponseEntity.ok(ApiResponse.noContent());
+	}
+
 	@Operation(summary = "문제 셋 제목 단건 수정 API", description = "연필 버튼 클릭을 통한 문제 셋 단건 수정")
 	@PatchMapping("/{questionSetId}")
 	public ResponseEntity<ApiResponse<Void>> updateQuestionSet(
 		@RequestBody @Valid UpdateQuestionSetFieldApiRequest request,
-		@PathVariable("questionSetId") Long questionSetId) {
+		@PathVariable Long questionSetId) {
 		questionSetService.updateQuestionSetField(questionSetId, request.title());
 		return ResponseEntity.ok(ApiResponse.noContent());
 	}
@@ -145,7 +158,7 @@ public class QuestionSetController {
 	@Operation(summary = "AI 문제 제작 상태 조회", description = "AI 문제 제작 상태를 조회합니다.")
 	@GetMapping("/{questionSetId}/ai-status")
 	public ResponseEntity<ApiResponse<AiRequestStatusApiResponse>> getAiRequestStatus(
-		@PathVariable("questionSetId") Long questionSetId) {
+		@PathVariable Long questionSetId) {
 		AiRequestStatus status = questionSetService.getAiRequestStatus(questionSetId);
 		return ResponseEntity.ok(ApiResponse.ok(AiRequestStatusApiResponse.of(questionSetId, status)));
 	}

--- a/src/main/java/com/coniv/mait/web/question/dto/CreateQuestionSetApiRequest.java
+++ b/src/main/java/com/coniv/mait/web/question/dto/CreateQuestionSetApiRequest.java
@@ -27,7 +27,9 @@ public record CreateQuestionSetApiRequest(
 	@Schema(description = "문제 난이도, AI 생성인 경우에만 활용")
 	String difficulty,
 	@Schema(description = "문제 셋에 대한 보충 설명, AI 생성인 경우에만 활용")
-	String instruction
+	String instruction,
+	@Schema(description = "문제 셋에 부착할 카테고리 ID 목록")
+	List<Long> categoryIds
 ) {
 
 	public CreateQuestionSetApiRequest {

--- a/src/main/java/com/coniv/mait/web/question/dto/QuestionSetApiResponse.java
+++ b/src/main/java/com/coniv/mait/web/question/dto/QuestionSetApiResponse.java
@@ -1,12 +1,14 @@
 package com.coniv.mait.web.question.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
 import com.coniv.mait.domain.question.enums.QuestionSetStatus;
 import com.coniv.mait.domain.question.enums.QuestionSetVisibility;
+import com.coniv.mait.domain.question.service.dto.QuestionSetCategoryDto;
 import com.coniv.mait.domain.question.service.dto.QuestionSetDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -38,6 +40,8 @@ public record QuestionSetApiResponse(
 	Long questionCount,
 	@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 	String difficulty,
+	@Schema(description = "문제 셋에 부착된 카테고리 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+	List<QuestionSetCategoryDto> categories,
 	@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
 	LocalDateTime updatedAt
 
@@ -55,6 +59,7 @@ public record QuestionSetApiResponse(
 			.teamId(questionSetDto.getTeamId())
 			.questionCount(questionSetDto.getQuestionCount())
 			.difficulty(questionSetDto.getDifficulty())
+			.categories(questionSetDto.getCategories() == null ? List.of() : questionSetDto.getCategories())
 			.updatedAt(questionSetDto.getUpdatedAt())
 			.build();
 	}

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetCategoryServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetCategoryServiceTest.java
@@ -15,9 +15,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
 import com.coniv.mait.domain.question.exception.QuestionSetCategoryException;
 import com.coniv.mait.domain.question.exception.code.QuestionSetCategoryExceptionCode;
 import com.coniv.mait.domain.question.repository.QuestionSetCategoryEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
 import com.coniv.mait.domain.question.service.dto.QuestionSetCategoryDto;
 import com.coniv.mait.domain.user.service.component.TeamRoleValidator;
 
@@ -32,6 +34,9 @@ class QuestionSetCategoryServiceTest {
 
 	@Mock
 	private QuestionSetCategoryEntityRepository questionSetCategoryEntityRepository;
+
+	@Mock
+	private QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
 
 	@Mock
 	private TeamRoleValidator teamRoleValidator;
@@ -328,5 +333,47 @@ class QuestionSetCategoryServiceTest {
 		assertThatThrownBy(() -> questionSetCategoryService.restoreCategory(teamId, name, userId))
 			.isInstanceOf(EntityNotFoundException.class)
 			.hasMessageContaining("복구할 카테고리를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("attachCategories - 모든 categoryId가 같은 팀의 활성 카테고리면 일괄 INSERT")
+	void attachCategories_savesAll() {
+		// given
+		Long questionSetId = 1L;
+		Long teamId = 100L;
+		List<Long> incoming = List.of(11L, 12L);
+
+		QuestionSetCategoryEntity category1 = mock(QuestionSetCategoryEntity.class);
+		QuestionSetCategoryEntity category2 = mock(QuestionSetCategoryEntity.class);
+
+		when(questionSetCategoryEntityRepository.findAllByIdInAndTeamIdAndDeletedAtIsNull(anySet(), eq(teamId)))
+			.thenReturn(List.of(category1, category2));
+
+		// when
+		questionSetCategoryService.attachCategories(questionSetId, teamId, incoming);
+
+		// then
+		verify(questionSetCategoryLinkEntityRepository, times(1)).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("attachCategories - 다른 팀 또는 미존재(또는 삭제된) 카테고리 포함 시 예외")
+	void attachCategories_invalidCategory_throws() {
+		// given
+		Long questionSetId = 1L;
+		Long teamId = 100L;
+		List<Long> incoming = List.of(11L, 12L);
+
+		QuestionSetCategoryEntity onlyOne = mock(QuestionSetCategoryEntity.class);
+
+		when(questionSetCategoryEntityRepository.findAllByIdInAndTeamIdAndDeletedAtIsNull(anySet(), eq(teamId)))
+			.thenReturn(List.of(onlyOne));
+
+		// when & then
+		assertThatThrownBy(() -> questionSetCategoryService.attachCategories(questionSetId, teamId, incoming))
+			.isInstanceOf(QuestionSetCategoryException.class)
+			.hasMessage(QuestionSetCategoryExceptionCode.INVALID_TEAM_OR_NOT_FOUND.getMessage());
+
+		verify(questionSetCategoryLinkEntityRepository, never()).saveAll(anyList());
 	}
 }

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetCategoryServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetCategoryServiceTest.java
@@ -16,10 +16,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
 import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetEntity;
 import com.coniv.mait.domain.question.exception.QuestionSetCategoryException;
 import com.coniv.mait.domain.question.exception.code.QuestionSetCategoryExceptionCode;
 import com.coniv.mait.domain.question.repository.QuestionSetCategoryEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
 import com.coniv.mait.domain.question.service.dto.QuestionSetCategoryDto;
 import com.coniv.mait.domain.user.service.component.TeamRoleValidator;
 
@@ -37,6 +39,9 @@ class QuestionSetCategoryServiceTest {
 
 	@Mock
 	private QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
+
+	@Mock
+	private QuestionSetEntityRepository questionSetEntityRepository;
 
 	@Mock
 	private TeamRoleValidator teamRoleValidator;
@@ -375,5 +380,151 @@ class QuestionSetCategoryServiceTest {
 			.hasMessage(QuestionSetCategoryExceptionCode.INVALID_TEAM_OR_NOT_FOUND.getMessage());
 
 		verify(questionSetCategoryLinkEntityRepository, never()).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("attachCategory - 활성 카테고리 단건 매핑 성공")
+	void attachCategory_success() {
+		// given
+		Long questionSetId = 1L;
+		Long categoryId = 11L;
+		Long teamId = 100L;
+		Long userId = 10L;
+
+		QuestionSetEntity questionSet = mock(QuestionSetEntity.class);
+		when(questionSet.getTeamId()).thenReturn(teamId);
+		QuestionSetCategoryEntity category = mock(QuestionSetCategoryEntity.class);
+
+		when(questionSetEntityRepository.findById(questionSetId)).thenReturn(Optional.of(questionSet));
+		when(questionSetCategoryLinkEntityRepository.existsByQuestionSetIdAndCategoryId(questionSetId, categoryId))
+			.thenReturn(false);
+		when(questionSetCategoryEntityRepository.findByIdAndTeamIdAndDeletedAtIsNull(categoryId, teamId))
+			.thenReturn(Optional.of(category));
+
+		// when
+		questionSetCategoryService.attachCategory(questionSetId, categoryId, userId);
+
+		// then
+		verify(teamRoleValidator).checkHasCreateQuestionSetAuthority(teamId, userId);
+		verify(questionSetCategoryLinkEntityRepository).save(any(QuestionSetCategoryLinkEntity.class));
+	}
+
+	@Test
+	@DisplayName("attachCategory - 이미 매핑된 카테고리는 멱등 처리 (save 호출 안 됨)")
+	void attachCategory_alreadyMapped_idempotent() {
+		// given
+		Long questionSetId = 1L;
+		Long categoryId = 11L;
+		Long teamId = 100L;
+		Long userId = 10L;
+
+		QuestionSetEntity questionSet = mock(QuestionSetEntity.class);
+		when(questionSet.getTeamId()).thenReturn(teamId);
+
+		when(questionSetEntityRepository.findById(questionSetId)).thenReturn(Optional.of(questionSet));
+		when(questionSetCategoryLinkEntityRepository.existsByQuestionSetIdAndCategoryId(questionSetId, categoryId))
+			.thenReturn(true);
+
+		// when
+		questionSetCategoryService.attachCategory(questionSetId, categoryId, userId);
+
+		// then
+		verify(questionSetCategoryEntityRepository, never())
+			.findByIdAndTeamIdAndDeletedAtIsNull(anyLong(), anyLong());
+		verify(questionSetCategoryLinkEntityRepository, never()).save(any(QuestionSetCategoryLinkEntity.class));
+	}
+
+	@Test
+	@DisplayName("attachCategory - 문제 셋이 존재하지 않으면 예외")
+	void attachCategory_questionSetNotFound_throws() {
+		// given
+		Long questionSetId = 999L;
+		Long categoryId = 11L;
+		Long userId = 10L;
+
+		when(questionSetEntityRepository.findById(questionSetId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> questionSetCategoryService.attachCategory(questionSetId, categoryId, userId))
+			.isInstanceOf(EntityNotFoundException.class)
+			.hasMessageContaining("문제 셋을 찾을 수 없습니다.");
+
+		verify(questionSetCategoryLinkEntityRepository, never()).save(any(QuestionSetCategoryLinkEntity.class));
+	}
+
+	@Test
+	@DisplayName("attachCategory - 다른 팀 또는 삭제된 카테고리는 EntityNotFoundException")
+	void attachCategory_categoryNotFoundOrOtherTeamOrDeleted_throws() {
+		// given
+		Long questionSetId = 1L;
+		Long categoryId = 11L;
+		Long teamId = 100L;
+		Long userId = 10L;
+
+		QuestionSetEntity questionSet = mock(QuestionSetEntity.class);
+		when(questionSet.getTeamId()).thenReturn(teamId);
+
+		when(questionSetEntityRepository.findById(questionSetId)).thenReturn(Optional.of(questionSet));
+		when(questionSetCategoryLinkEntityRepository.existsByQuestionSetIdAndCategoryId(questionSetId, categoryId))
+			.thenReturn(false);
+		when(questionSetCategoryEntityRepository.findByIdAndTeamIdAndDeletedAtIsNull(categoryId, teamId))
+			.thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> questionSetCategoryService.attachCategory(questionSetId, categoryId, userId))
+			.isInstanceOf(EntityNotFoundException.class)
+			.hasMessageContaining("해당 카테고리를 찾을 수 없습니다.");
+
+		verify(questionSetCategoryLinkEntityRepository, never()).save(any(QuestionSetCategoryLinkEntity.class));
+	}
+
+	@Test
+	@DisplayName("getCategoriesByQuestionSetId - 매핑이 없으면 빈 리스트")
+	void getCategoriesByQuestionSetId_noLinks_returnsEmpty() {
+		// given
+		Long questionSetId = 1L;
+		when(questionSetCategoryLinkEntityRepository.findAllByQuestionSetId(questionSetId)).thenReturn(List.of());
+
+		// when
+		List<QuestionSetCategoryDto> result = questionSetCategoryService.getCategoriesByQuestionSetId(questionSetId);
+
+		// then
+		assertThat(result).isEmpty();
+		verify(questionSetCategoryEntityRepository, never()).findAllByIdIn(anySet());
+	}
+
+	@Test
+	@DisplayName("getCategoriesByQuestionSetId - 매핑된 카테고리(삭제 포함)를 DTO 로 변환")
+	void getCategoriesByQuestionSetId_returnsMappedCategoriesIncludingDeleted() {
+		// given
+		Long questionSetId = 1L;
+		Long activeId = 11L;
+		Long deletedId = 12L;
+
+		QuestionSetCategoryLinkEntity activeLink = QuestionSetCategoryLinkEntity.of(questionSetId, activeId);
+		QuestionSetCategoryLinkEntity deletedLink = QuestionSetCategoryLinkEntity.of(questionSetId, deletedId);
+
+		QuestionSetCategoryEntity activeCategory = mock(QuestionSetCategoryEntity.class);
+		when(activeCategory.getId()).thenReturn(activeId);
+		when(activeCategory.getName()).thenReturn("활성");
+		when(activeCategory.deleted()).thenReturn(false);
+
+		QuestionSetCategoryEntity deletedCategory = mock(QuestionSetCategoryEntity.class);
+		when(deletedCategory.getId()).thenReturn(deletedId);
+		when(deletedCategory.getName()).thenReturn("삭제됨");
+		when(deletedCategory.deleted()).thenReturn(true);
+
+		when(questionSetCategoryLinkEntityRepository.findAllByQuestionSetId(questionSetId))
+			.thenReturn(List.of(activeLink, deletedLink));
+		when(questionSetCategoryEntityRepository.findAllByIdIn(anySet()))
+			.thenReturn(List.of(activeCategory, deletedCategory));
+
+		// when
+		List<QuestionSetCategoryDto> result = questionSetCategoryService.getCategoriesByQuestionSetId(questionSetId);
+
+		// then
+		assertThat(result).hasSize(2);
+		assertThat(result).extracting(QuestionSetCategoryDto::isDeleted)
+			.containsExactlyInAnyOrder(false, true);
 	}
 }

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
@@ -62,6 +62,9 @@ class QuestionSetServiceTest {
 	@Mock
 	private AiRequestStatusManager aiRequestStatusManager;
 
+	@Mock
+	private QuestionSetCategoryService questionSetCategoryService;
+
 	// Todo: 생성 관련 feature가 최종 완성 시에 수정
 	// @Test
 	// @DisplayName("문제 셋 생성 테스트")

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,8 @@ import org.springframework.http.MediaType;
 
 import com.coniv.mait.domain.question.entity.MultipleChoiceEntity;
 import com.coniv.mait.domain.question.entity.MultipleQuestionEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
 import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
@@ -21,6 +25,8 @@ import com.coniv.mait.domain.question.enums.QuestionSetStatus;
 import com.coniv.mait.domain.question.enums.QuestionSetVisibility;
 import com.coniv.mait.domain.question.repository.MultipleChoiceEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
 import com.coniv.mait.domain.solve.entity.SolvingSessionEntity;
 import com.coniv.mait.domain.solve.repository.SolvingSessionEntityRepository;
@@ -60,10 +66,18 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private UserEntityRepository userEntityRepository;
 
+	@Autowired
+	private QuestionSetCategoryEntityRepository questionSetCategoryEntityRepository;
+
+	@Autowired
+	private QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
+
 	@BeforeEach
 	void setUp() {
 		solvingSessionEntityRepository.deleteAll();
 		teamUserEntityRepository.deleteAll();
+		questionSetCategoryLinkEntityRepository.deleteAll();
+		questionSetCategoryEntityRepository.deleteAll();
 		questionSetEntityRepository.deleteAll();
 		questionEntityRepository.deleteAll();
 		multipleChoiceEntityRepository.deleteAll();
@@ -334,6 +348,46 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 				jsonPath("$.data.title").value("Updated Title"),
 				jsonPath("$.data.subject").value("Updated Subject"),
 				jsonPath("$.data.deliveryMode").value(DeliveryMode.LIVE_TIME.name()));
+	}
+
+	@Test
+	@DisplayName("문제 셋 단건 조회 API - 매핑된 카테고리(삭제 포함) 응답 포함")
+	void getQuestionSetApiSuccess_IncludesCategoriesWithDeletedFlag() throws Exception {
+		// given
+		UserEntity currentUser = userEntityRepository.findByEmail("user@example.com").orElseThrow();
+		TeamEntity team = teamEntityRepository.save(TeamEntity.builder().name("코니브").creatorId(1L).build());
+		teamUserEntityRepository.save(TeamUserEntity.createTeamUser(currentUser, team, TeamUserRole.MAKER));
+
+		QuestionSetCategoryEntity activeCategory = questionSetCategoryEntityRepository.save(
+			QuestionSetCategoryEntity.of(team.getId(), "활성카테고리"));
+		QuestionSetCategoryEntity deletedCategory = questionSetCategoryEntityRepository.save(
+			QuestionSetCategoryEntity.of(team.getId(), "삭제된카테고리"));
+		deletedCategory.markDeleted();
+		questionSetCategoryEntityRepository.save(deletedCategory);
+
+		QuestionSetEntity questionSet = questionSetEntityRepository.save(
+			QuestionSetEntity.builder()
+				.subject("Sample Subject")
+				.teamId(team.getId())
+				.creationType(QuestionSetCreationType.MANUAL)
+				.build());
+
+		questionSetCategoryLinkEntityRepository.save(
+			QuestionSetCategoryLinkEntity.of(questionSet.getId(), activeCategory.getId()));
+		questionSetCategoryLinkEntityRepository.save(
+			QuestionSetCategoryLinkEntity.of(questionSet.getId(), deletedCategory.getId()));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/question-sets/{questionSetId}", questionSet.getId())
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.data.id").value(questionSet.getId()),
+				jsonPath("$.data.categories.length()").value(2),
+				jsonPath("$.data.categories[?(@.deleted == true)].name")
+					.value(hasItem("삭제된카테고리")),
+				jsonPath("$.data.categories[?(@.deleted == false)].name")
+					.value(hasItem("활성카테고리")));
 	}
 
 	@Test

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
@@ -351,6 +351,35 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("문제 셋에 카테고리 단건 매핑 추가 API 성공 - DB 에 매핑 row 저장")
+	void attachCategoryApiSuccess() throws Exception {
+		// given
+		UserEntity currentUser = userEntityRepository.findByEmail("user@example.com").orElseThrow();
+		TeamEntity team = teamEntityRepository.save(TeamEntity.builder().name("코니브").creatorId(1L).build());
+		teamUserEntityRepository.save(TeamUserEntity.createTeamUser(currentUser, team, TeamUserRole.MAKER));
+
+		QuestionSetCategoryEntity category = questionSetCategoryEntityRepository.save(
+			QuestionSetCategoryEntity.of(team.getId(), "알고리즘"));
+
+		QuestionSetEntity questionSet = questionSetEntityRepository.save(
+			QuestionSetEntity.builder()
+				.subject("Initial Subject")
+				.teamId(team.getId())
+				.creationType(QuestionSetCreationType.MANUAL)
+				.build());
+
+		// when & then
+		mockMvc.perform(post("/api/v1/question-sets/{questionSetId}/categories/{categoryId}",
+				questionSet.getId(), category.getId()))
+			.andExpect(status().isOk());
+
+		List<QuestionSetCategoryLinkEntity> links =
+			questionSetCategoryLinkEntityRepository.findAllByQuestionSetId(questionSet.getId());
+		assertThat(links).hasSize(1);
+		assertThat(links.get(0).getCategoryId()).isEqualTo(category.getId());
+	}
+
+	@Test
 	@DisplayName("문제 셋 단건 조회 API - 매핑된 카테고리(삭제 포함) 응답 포함")
 	void getQuestionSetApiSuccess_IncludesCategoriesWithDeletedFlag() throws Exception {
 		// given

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
@@ -441,6 +441,21 @@ class QuestionSetControllerTest {
 			visibility);
 	}
 
+	@Test
+	@DisplayName("문제 셋에 카테고리 단건 매핑 추가 API 성공 테스트")
+	void attachCategoryApiSuccess() throws Exception {
+		// given
+		final Long questionSetId = 1L;
+		final Long categoryId = 11L;
+
+		// when & then
+		mockMvc.perform(post("/api/v1/question-sets/{questionSetId}/categories/{categoryId}",
+				questionSetId, categoryId))
+			.andExpect(status().isOk());
+
+		verify(questionSetCategoryService).attachCategory(questionSetId, categoryId, USER_ID);
+	}
+
 	@ParameterizedTest(name = "{index} - {0}")
 	@DisplayName("문제 셋 최종 저장 테스트 - 유효하지 않은 요청")
 	@MethodSource("invalidUpdateQuestionSetRequests")

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetControllerTest.java
@@ -31,6 +31,7 @@ import com.coniv.mait.domain.question.enums.QuestionSetStatus;
 import com.coniv.mait.domain.question.enums.QuestionSetVisibility;
 import com.coniv.mait.domain.question.enums.QuestionValidationResult;
 import com.coniv.mait.domain.question.enums.UserStudyStatus;
+import com.coniv.mait.domain.question.service.QuestionSetCategoryService;
 import com.coniv.mait.domain.question.service.QuestionSetDeleteService;
 import com.coniv.mait.domain.question.service.QuestionSetMaterialService;
 import com.coniv.mait.domain.question.service.QuestionSetService;
@@ -67,6 +68,9 @@ class QuestionSetControllerTest {
 
 	@MockitoBean
 	private QuestionSetMaterialService questionSetMaterialService;
+
+	@MockitoBean
+	private QuestionSetCategoryService questionSetCategoryService;
 
 	@Autowired
 	private MockMvc mockMvc;


### PR DESCRIPTION
### Motivation

<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

문제 셋에 카테고리를 추가해야한다.
2가지 포인트에서 추가 및 수정이 가능하다.

1. 문제 셋 생성(초안) 시점
2. 생성한 문제 셋 저장하는 시점 

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

1. 생성하는 시점 -> List로 같이 저장
2. 추가 -> 단건 추가 수정

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)

<!-- 테스트 결과를 보여주세요. -->

- [x] 단위테스트를 작성했는지
- [x] 컨트롤러 단위테스트를 작성했는지
- [x] 통합테스트를 작성했는지

### SQL

<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->

```sql
⏺ CREATE TABLE question_set_category_links (                                                                                     id BIGINT NOT NULL AUTO_INCREMENT,
      question_set_id BIGINT NOT NULL,                                                                                           category_id BIGINT NOT NULL,
      created_at DATETIME(6),                                                                                                    modified_at DATETIME(6),
      PRIMARY KEY (id),
      UNIQUE KEY uk_question_set_category_links_set_category (question_set_id, category_id),                                     KEY idx_question_set_category_links_category_set (category_id, question_set_id)
  ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
```
