### PR TITLE
[EDU-536] 개인워크스페이스 문제 셋 생성 시 진행중 상태로 고정

### DIFF
--- a/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetEntity.java
+++ b/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetEntity.java
@@ -154,6 +154,11 @@ public class QuestionSetEntity extends BaseTimeEntity {
 		this.visibility = visibility;
 	}
 
+	public void markOngoingOnComplete() {
+		this.status = QuestionSetStatus.ONGOING;
+		this.startTime = LocalDateTime.now();
+	}
+
 	public void updateTitle(String title) {
 		this.title = title;
 	}

--- a/src/main/java/com/coniv/mait/domain/question/exception/code/QuestionSetStatusExceptionCode.java
+++ b/src/main/java/com/coniv/mait/domain/question/exception/code/QuestionSetStatusExceptionCode.java
@@ -20,6 +20,8 @@ public enum QuestionSetStatusExceptionCode implements ExceptionCode {
 	ONLY_STUDY(HttpStatus.BAD_REQUEST, "2002", "학습 모드의 문제 셋만 처리가 가능합니다."),
 	CANNOT_CREATE_LIVE_TIME_IN_PERSONAL_TEAM(HttpStatus.BAD_REQUEST, "2003",
 		"개인 워크스페이스에서는 실시간 문제 셋을 생성할 수 없습니다."),
+	CANNOT_END_STUDY_IN_PERSONAL_TEAM(HttpStatus.BAD_REQUEST, "2004",
+		"개인 워크스페이스의 학습 문제 셋은 종료할 수 없습니다."),
 	CANNOT_DELETE_ONGOING(HttpStatus.CONFLICT, "3001", "진행중인 문제 셋은 삭제할 수 없습니다. 먼저 종료해주세요.");
 
 	private final HttpStatus status;

--- a/src/main/java/com/coniv/mait/domain/question/service/QuestionSetService.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/QuestionSetService.java
@@ -14,6 +14,7 @@ import com.coniv.mait.domain.question.enums.AiRequestStatus;
 import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
+import com.coniv.mait.domain.question.enums.QuestionSetStatus;
 import com.coniv.mait.domain.question.enums.QuestionSetVisibility;
 import com.coniv.mait.domain.question.event.AiQuestionGenerationRequestedEvent;
 import com.coniv.mait.domain.question.exception.QuestionSetStatusException;
@@ -183,6 +184,9 @@ public class QuestionSetService {
 		}
 
 		questionSet.completeQuestionSet(title, subject, solveMode, difficulty, visibility);
+		if (team.getType() == TeamType.PERSONAL) {
+			questionSet.markOngoingOnComplete();
+		}
 		questionSetCategoryService.updateLinkedCategories(questionSetId, questionSet.getTeamId(), categoryIds);
 
 		return QuestionSetDto.from(questionSet);

--- a/src/main/java/com/coniv/mait/domain/question/service/QuestionSetStudyControlService.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/QuestionSetStudyControlService.java
@@ -6,10 +6,14 @@ import org.springframework.transaction.annotation.Transactional;
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
 import com.coniv.mait.domain.question.enums.QuestionSetStatus;
+import com.coniv.mait.domain.question.exception.QuestionSetStatusException;
+import com.coniv.mait.domain.question.exception.code.QuestionSetStatusExceptionCode;
 import com.coniv.mait.domain.question.service.component.QuestionSetReader;
 import com.coniv.mait.domain.solve.enums.SolvingStatus;
 import com.coniv.mait.domain.solve.repository.SolvingSessionEntityRepository;
+import com.coniv.mait.domain.team.enums.TeamType;
 import com.coniv.mait.domain.team.repository.TeamUserEntityRepository;
+import com.coniv.mait.domain.team.service.component.TeamReader;
 import com.coniv.mait.domain.user.service.component.TeamRoleValidator;
 import com.coniv.mait.global.auth.model.MaitUser;
 
@@ -25,6 +29,7 @@ public class QuestionSetStudyControlService {
 	private final TeamRoleValidator teamRoleValidator;
 	private final SolvingSessionEntityRepository solvingSessionEntityRepository;
 	private final TeamUserEntityRepository teamUserEntityRepository;
+	private final TeamReader teamReader;
 
 	@Transactional
 	public void startStudyQuestionSet(final MaitUser user, final Long questionSetId) {
@@ -39,6 +44,9 @@ public class QuestionSetStudyControlService {
 	public void endStudyQuestionSet(final MaitUser user, final Long questionSetId) {
 		QuestionSetEntity questionSet = questionSetReader.getQuestionSet(questionSetId);
 		teamRoleValidator.checkHasCreateQuestionSetAuthority(questionSet.getTeamId(), user.id());
+		if (teamReader.getTeam(questionSet.getTeamId()).getType() == TeamType.PERSONAL) {
+			throw new QuestionSetStatusException(QuestionSetStatusExceptionCode.CANNOT_END_STUDY_IN_PERSONAL_TEAM);
+		}
 		questionSet.endStudyQuestionSet();
 		log.info("[학습 문제 셋 종료] questionSetId={}, teamId={}, endedBy={}",
 			questionSetId, questionSet.getTeamId(), user.id());
@@ -50,6 +58,10 @@ public class QuestionSetStudyControlService {
 
 		if (!(questionSet.getSolveMode() == QuestionSetSolveMode.STUDY
 			&& questionSet.getStatus() == QuestionSetStatus.ONGOING)) {
+			return;
+		}
+
+		if (teamReader.getTeam(questionSet.getTeamId()).getType() == TeamType.PERSONAL) {
 			return;
 		}
 

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
@@ -418,7 +418,7 @@ class QuestionSetServiceTest {
 	}
 
 	@Test
-	@DisplayName("문제 셋 완료 처리 테스트 - 성공 (개인 워크스페이스에서 학습 모드 생성)")
+	@DisplayName("문제 셋 완료 처리 테스트 - 성공 (개인 워크스페이스 학습 모드 생성 시 풀이 중 상태로 전환)")
 	void completeQuestionSetTest_PersonalTeamWithStudyMode() {
 		// given
 		final Long questionSetId = 1L;
@@ -448,6 +448,8 @@ class QuestionSetServiceTest {
 
 		// then
 		assertThat(questionSetEntity.getSolveMode()).isEqualTo(QuestionSetSolveMode.STUDY);
+		assertThat(questionSetEntity.getStatus()).isEqualTo(QuestionSetStatus.ONGOING);
+		assertThat(questionSetEntity.getStartTime()).isNotNull();
 	}
 
 	@Test

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetStudyControlServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetStudyControlServiceTest.java
@@ -14,10 +14,13 @@ import com.coniv.mait.domain.question.entity.QuestionSetEntity;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
 import com.coniv.mait.domain.question.enums.QuestionSetStatus;
 import com.coniv.mait.domain.question.exception.QuestionSetStatusException;
+import com.coniv.mait.domain.question.exception.code.QuestionSetStatusExceptionCode;
 import com.coniv.mait.domain.question.service.component.QuestionSetReader;
 import com.coniv.mait.domain.solve.enums.SolvingStatus;
 import com.coniv.mait.domain.solve.repository.SolvingSessionEntityRepository;
+import com.coniv.mait.domain.team.entity.TeamEntity;
 import com.coniv.mait.domain.team.repository.TeamUserEntityRepository;
+import com.coniv.mait.domain.team.service.component.TeamReader;
 import com.coniv.mait.domain.user.exception.UserRoleException;
 import com.coniv.mait.domain.user.service.component.TeamRoleValidator;
 import com.coniv.mait.global.auth.model.MaitUser;
@@ -46,6 +49,9 @@ class QuestionSetStudyControlServiceTest {
 
 	@Mock
 	private TeamUserEntityRepository teamUserEntityRepository;
+
+	@Mock
+	private TeamReader teamReader;
 
 	@Test
 	@DisplayName("MAKER가 STUDY 모드 BEFORE 상태 문제 셋을 시작하면 ONGOING으로 전환된다")
@@ -148,6 +154,7 @@ class QuestionSetStudyControlServiceTest {
 			.build();
 
 		when(questionSetReader.getQuestionSet(QUESTION_SET_ID)).thenReturn(questionSet);
+		when(teamReader.getTeam(TEAM_ID)).thenReturn(TeamEntity.ofGroup("팀", 1L));
 
 		// when
 		questionSetStudyControlService.endStudyQuestionSet(MAIT_USER, QUESTION_SET_ID);
@@ -202,6 +209,7 @@ class QuestionSetStudyControlServiceTest {
 			.build();
 
 		when(questionSetReader.getQuestionSet(QUESTION_SET_ID)).thenReturn(questionSet);
+		when(teamReader.getTeam(TEAM_ID)).thenReturn(TeamEntity.ofGroup("팀", 1L));
 
 		// when & then
 		assertThatThrownBy(() ->
@@ -220,6 +228,7 @@ class QuestionSetStudyControlServiceTest {
 			.build();
 
 		when(questionSetReader.getQuestionSet(QUESTION_SET_ID)).thenReturn(questionSet);
+		when(teamReader.getTeam(TEAM_ID)).thenReturn(TeamEntity.ofGroup("팀", 1L));
 
 		// when & then
 		assertThatThrownBy(() ->
@@ -278,6 +287,7 @@ class QuestionSetStudyControlServiceTest {
 			.build();
 
 		when(questionSetReader.getQuestionSet(QUESTION_SET_ID)).thenReturn(questionSet);
+		when(teamReader.getTeam(TEAM_ID)).thenReturn(TeamEntity.ofGroup("팀", 1L));
 		when(solvingSessionEntityRepository.countByQuestionSetIdAndSolveModeAndStatus(
 			QUESTION_SET_ID, QuestionSetSolveMode.STUDY, SolvingStatus.PROGRESSING))
 			.thenReturn(1L);
@@ -301,6 +311,7 @@ class QuestionSetStudyControlServiceTest {
 			.build();
 
 		when(questionSetReader.getQuestionSet(QUESTION_SET_ID)).thenReturn(questionSet);
+		when(teamReader.getTeam(TEAM_ID)).thenReturn(TeamEntity.ofGroup("팀", 1L));
 		when(solvingSessionEntityRepository.countByQuestionSetIdAndSolveModeAndStatus(
 			QUESTION_SET_ID, QuestionSetSolveMode.STUDY, SolvingStatus.PROGRESSING))
 			.thenReturn(0L);
@@ -327,6 +338,7 @@ class QuestionSetStudyControlServiceTest {
 			.build();
 
 		when(questionSetReader.getQuestionSet(QUESTION_SET_ID)).thenReturn(questionSet);
+		when(teamReader.getTeam(TEAM_ID)).thenReturn(TeamEntity.ofGroup("팀", 1L));
 		when(solvingSessionEntityRepository.countByQuestionSetIdAndSolveModeAndStatus(
 			QUESTION_SET_ID, QuestionSetSolveMode.STUDY, SolvingStatus.PROGRESSING))
 			.thenReturn(0L);
@@ -341,5 +353,51 @@ class QuestionSetStudyControlServiceTest {
 		// then
 		assertThat(questionSet.getStatus()).isEqualTo(QuestionSetStatus.AFTER);
 		assertThat(questionSet.getEndTime()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("개인 워크스페이스의 학습 문제 셋은 수동 종료할 수 없다")
+	void endStudyQuestionSet_PersonalTeam_ThrowsException() {
+		// given
+		QuestionSetEntity questionSet = QuestionSetEntity.builder()
+			.teamId(TEAM_ID)
+			.solveMode(QuestionSetSolveMode.STUDY)
+			.status(QuestionSetStatus.ONGOING)
+			.build();
+
+		when(questionSetReader.getQuestionSet(QUESTION_SET_ID)).thenReturn(questionSet);
+		when(teamReader.getTeam(TEAM_ID)).thenReturn(TeamEntity.ofPersonal("개인 워크스페이스", 1L));
+
+		// when & then
+		assertThatThrownBy(() ->
+			questionSetStudyControlService.endStudyQuestionSet(MAIT_USER, QUESTION_SET_ID))
+			.isInstanceOfSatisfying(QuestionSetStatusException.class, ex -> {
+				assertThat(ex.getExceptionCode())
+					.isEqualTo(QuestionSetStatusExceptionCode.CANNOT_END_STUDY_IN_PERSONAL_TEAM);
+				assertThat(ex.getMessage())
+					.isEqualTo(QuestionSetStatusExceptionCode.CANNOT_END_STUDY_IN_PERSONAL_TEAM.getMessage());
+			});
+		assertThat(questionSet.getStatus()).isEqualTo(QuestionSetStatus.ONGOING);
+	}
+
+	@Test
+	@DisplayName("개인 워크스페이스의 학습 문제 셋은 자동 종료되지 않는다")
+	void evaluateAndAutoEnd_PersonalTeam_DoesNothing() {
+		// given
+		QuestionSetEntity questionSet = QuestionSetEntity.builder()
+			.teamId(TEAM_ID)
+			.solveMode(QuestionSetSolveMode.STUDY)
+			.status(QuestionSetStatus.ONGOING)
+			.build();
+
+		when(questionSetReader.getQuestionSet(QUESTION_SET_ID)).thenReturn(questionSet);
+		when(teamReader.getTeam(TEAM_ID)).thenReturn(TeamEntity.ofPersonal("개인 워크스페이스", 1L));
+
+		// when
+		questionSetStudyControlService.evaluateAndAutoEnd(QUESTION_SET_ID);
+
+		// then
+		assertThat(questionSet.getStatus()).isEqualTo(QuestionSetStatus.ONGOING);
+		verifyNoInteractions(solvingSessionEntityRepository, teamUserEntityRepository);
 	}
 }


### PR DESCRIPTION
### Motivation

<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

명세상 개인워크스페이스는 풀이 시작, 종료 기능이 존재하지 않음

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

생성 시점에 진행중 상태를 넣자

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)

<!-- 테스트 결과를 보여주세요. -->

- [x] 단위테스트를 작성했는지
- [x] 컨트롤러 단위테스트를 작성했는지
- [x] 통합테스트를 작성했는지

### SQL

<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->

```sql

```
