### PR TITLE
[EDU-497] 유저의 카테고리별 정답률 조회 API

### DIFF
--- a/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetCategoryLinkEntityRepository.java
+++ b/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetCategoryLinkEntityRepository.java
@@ -13,6 +13,10 @@ public interface QuestionSetCategoryLinkEntityRepository
 
 	List<QuestionSetCategoryLinkEntity> findAllByQuestionSetId(Long questionSetId);
 
+	List<QuestionSetCategoryLinkEntity> findAllByCategoryId(Long categoryId);
+
+	List<QuestionSetCategoryLinkEntity> findAllByCategoryIdIn(Collection<Long> categoryIds);
+
 	boolean existsByQuestionSetIdAndCategoryId(Long questionSetId, Long categoryId);
 
 	@Modifying(clearAutomatically = true)

--- a/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetEntityRepository.java
+++ b/src/main/java/com/coniv/mait/domain/question/repository/QuestionSetEntityRepository.java
@@ -17,4 +17,6 @@ public interface QuestionSetEntityRepository extends JpaRepository<QuestionSetEn
 
 	List<QuestionSetEntity> findAllByTeamIdAndSolveModeAndStatusIn(Long teamId, QuestionSetSolveMode solveMode,
 		List<QuestionSetStatus> statuses);
+
+	List<QuestionSetEntity> findAllByIdInAndStatusIn(List<Long> ids, List<QuestionSetStatus> statuses);
 }

--- a/src/main/java/com/coniv/mait/domain/question/service/component/QuestionSetReader.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/component/QuestionSetReader.java
@@ -1,12 +1,22 @@
 package com.coniv.mait.domain.question.service.component;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
+import com.coniv.mait.domain.question.entity.QuestionEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
 import com.coniv.mait.domain.question.enums.QuestionSetStatus;
+import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -17,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 public class QuestionSetReader {
 
 	private final QuestionSetEntityRepository questionSetEntityRepository;
+	private final QuestionEntityRepository questionEntityRepository;
+	private final QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
 
 	public QuestionSetEntity getQuestionSet(final Long questionSetId) {
 		return questionSetEntityRepository.findById(questionSetId)
@@ -27,5 +39,47 @@ public class QuestionSetReader {
 		final QuestionSetSolveMode solveMode) {
 		return questionSetEntityRepository.findAllByTeamIdAndSolveModeAndStatusIn(teamId,
 			solveMode, List.of(QuestionSetStatus.AFTER, QuestionSetStatus.REVIEW));
+	}
+
+	public List<QuestionSetEntity> getFinishedQuestionSets(final List<Long> questionSetIds) {
+		if (questionSetIds.isEmpty()) {
+			return List.of();
+		}
+		return questionSetEntityRepository.findAllByIdInAndStatusIn(questionSetIds,
+			List.of(QuestionSetStatus.AFTER, QuestionSetStatus.REVIEW));
+	}
+
+	public Map<Long, List<QuestionSetEntity>> getFinishedQuestionSetsByCategoryId(
+		final List<QuestionSetCategoryEntity> categories) {
+		List<Long> categoryIds = categories.stream().map(QuestionSetCategoryEntity::getId).toList();
+		if (categoryIds.isEmpty()) {
+			return Map.of();
+		}
+
+		Map<Long, List<Long>> questionSetIdsByCategoryId =
+			questionSetCategoryLinkEntityRepository.findAllByCategoryIdIn(categoryIds).stream()
+				.collect(Collectors.groupingBy(QuestionSetCategoryLinkEntity::getCategoryId,
+					Collectors.mapping(QuestionSetCategoryLinkEntity::getQuestionSetId, Collectors.toList())));
+
+		List<Long> allQuestionSetIds = questionSetIdsByCategoryId.values().stream()
+			.flatMap(List::stream)
+			.distinct()
+			.toList();
+		Map<Long, QuestionSetEntity> finishedById = getFinishedQuestionSets(allQuestionSetIds).stream()
+			.collect(Collectors.toUnmodifiableMap(QuestionSetEntity::getId, Function.identity()));
+
+		return questionSetIdsByCategoryId.entrySet().stream()
+			.collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> entry.getValue().stream()
+				.map(finishedById::get)
+				.filter(Objects::nonNull)
+				.toList()));
+	}
+
+	public Map<Long, List<QuestionEntity>> getQuestionsByQuestionSetId(final Collection<Long> questionSetIds) {
+		if (questionSetIds.isEmpty()) {
+			return Map.of();
+		}
+		return questionEntityRepository.findAllByQuestionSetIdIn(questionSetIds.stream().toList()).stream()
+			.collect(Collectors.groupingBy(question -> question.getQuestionSet().getId()));
 	}
 }

--- a/src/main/java/com/coniv/mait/domain/statistic/service/CategoryStatisticService.java
+++ b/src/main/java/com/coniv/mait/domain/statistic/service/CategoryStatisticService.java
@@ -1,0 +1,120 @@
+package com.coniv.mait.domain.statistic.service;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coniv.mait.domain.question.entity.QuestionEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetEntity;
+import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
+import com.coniv.mait.domain.question.service.component.QuestionSetReader;
+import com.coniv.mait.domain.statistic.service.component.QuestionSetStatisticCalculator;
+import com.coniv.mait.domain.statistic.service.dto.CategoryCorrectRateDto;
+import com.coniv.mait.domain.user.service.component.TeamRoleValidator;
+import com.coniv.mait.global.auth.model.MaitUser;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryStatisticService {
+
+	/** 내 정답률 높은 순, 미응시(null)는 항상 맨 뒤, 동률이면 카테고리 이름 오름차순. */
+	private static final Comparator<CategoryCorrectRateDto> RANK_COMPARATOR =
+		Comparator.comparing(CategoryCorrectRateDto::getMyCorrectRate,
+				Comparator.nullsLast(Comparator.reverseOrder()))
+			.thenComparing(CategoryCorrectRateDto::getCategoryName);
+
+	private final QuestionSetCategoryEntityRepository questionSetCategoryEntityRepository;
+	private final QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
+	private final QuestionSetReader questionSetReader;
+	private final QuestionEntityRepository questionEntityRepository;
+	private final TeamRoleValidator teamRoleValidator;
+	private final QuestionSetStatisticCalculator questionSetStatisticCalculator;
+
+	@Transactional(readOnly = true)
+	public CategoryCorrectRateDto getCategoryCorrectRate(final MaitUser user, final Long teamId,
+		final Long categoryId) {
+		teamRoleValidator.checkHasSolveQuestionAuthorityInTeam(teamId, user.id());
+
+		QuestionSetCategoryEntity category = questionSetCategoryEntityRepository
+			.findByIdAndTeamIdAndDeletedAtIsNull(categoryId, teamId)
+			.orElseThrow(() -> new EntityNotFoundException("해당 카테고리를 찾을 수 없습니다."));
+
+		List<Long> linkedQuestionSetIds = questionSetCategoryLinkEntityRepository.findAllByCategoryId(categoryId)
+			.stream()
+			.map(QuestionSetCategoryLinkEntity::getQuestionSetId)
+			.toList();
+
+		List<Long> finishedQuestionSetIds = questionSetReader.getFinishedQuestionSets(linkedQuestionSetIds)
+			.stream()
+			.map(QuestionSetEntity::getId)
+			.toList();
+		if (finishedQuestionSetIds.isEmpty()) {
+			return CategoryCorrectRateDto.of(category, 0, null, 0.0);
+		}
+
+		List<QuestionEntity> questions = questionEntityRepository.findAllByQuestionSetIdIn(finishedQuestionSetIds);
+
+		Double myCorrectRate = questionSetStatisticCalculator.calculateUserCorrectRate(user.id(), questions);
+		double averageCorrectRate = questionSetStatisticCalculator.calculateOverallCorrectRate(questions);
+
+		return CategoryCorrectRateDto.of(category, finishedQuestionSetIds.size(), myCorrectRate, averageCorrectRate);
+	}
+
+	@Transactional(readOnly = true)
+	public List<CategoryCorrectRateDto> getCategoryCorrectRates(final MaitUser user, final Long teamId) {
+		teamRoleValidator.checkHasSolveQuestionAuthorityInTeam(teamId, user.id());
+
+		List<QuestionSetCategoryEntity> categories =
+			questionSetCategoryEntityRepository.findAllByTeamIdAndDeletedAtIsNullOrderByCreatedAtAsc(teamId);
+		if (categories.isEmpty()) {
+			return List.of();
+		}
+
+		Map<Long, List<QuestionSetEntity>> finishedSetsByCategoryId =
+			questionSetReader.getFinishedQuestionSetsByCategoryId(categories);
+		List<Long> finishedQuestionSetIds = finishedSetsByCategoryId.values().stream()
+			.flatMap(List::stream)
+			.map(QuestionSetEntity::getId)
+			.distinct()
+			.toList();
+		Map<Long, List<QuestionEntity>> questionsByQuestionSetId =
+			questionSetReader.getQuestionsByQuestionSetId(finishedQuestionSetIds);
+
+		Map<Long, List<QuestionEntity>> questionsByCategoryId = new HashMap<>();
+		Map<Long, Integer> finishedQuestionSetCountByCategoryId = new HashMap<>();
+
+		for (QuestionSetCategoryEntity category : categories) {
+			List<QuestionSetEntity> finishedSets = finishedSetsByCategoryId.getOrDefault(category.getId(), List.of());
+			List<QuestionEntity> questions = finishedSets.stream()
+				.flatMap(questionSet ->
+					questionsByQuestionSetId.getOrDefault(questionSet.getId(), List.of()).stream())
+				.toList();
+			questionsByCategoryId.put(category.getId(), questions);
+			finishedQuestionSetCountByCategoryId.put(category.getId(), finishedSets.size());
+		}
+
+		Map<Long, Double> myRates = questionSetStatisticCalculator.calculateUserCorrectRates(user.id(),
+			questionsByCategoryId);
+		Map<Long, Double> averageRates = questionSetStatisticCalculator.calculateOverallCorrectRates(
+			questionsByCategoryId);
+
+		return categories.stream()
+			.map(category -> CategoryCorrectRateDto.of(category,
+				finishedQuestionSetCountByCategoryId.getOrDefault(category.getId(), 0),
+				myRates.get(category.getId()),
+				averageRates.getOrDefault(category.getId(), 0.0)))
+			.sorted(RANK_COMPARATOR)
+			.toList();
+	}
+}

--- a/src/main/java/com/coniv/mait/domain/statistic/service/dto/CategoryCorrectRateDto.java
+++ b/src/main/java/com/coniv/mait/domain/statistic/service/dto/CategoryCorrectRateDto.java
@@ -1,0 +1,28 @@
+package com.coniv.mait.domain.statistic.service.dto;
+
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CategoryCorrectRateDto {
+
+	private Long categoryId;
+	private String categoryName;
+	private int questionSetCount;
+	private Double myCorrectRate;
+	private double averageCorrectRate;
+
+	public static CategoryCorrectRateDto of(final QuestionSetCategoryEntity category, final int questionSetCount,
+		final Double myCorrectRate, final double averageCorrectRate) {
+		return CategoryCorrectRateDto.builder()
+			.categoryId(category.getId())
+			.categoryName(category.getName())
+			.questionSetCount(questionSetCount)
+			.myCorrectRate(myCorrectRate)
+			.averageCorrectRate(averageCorrectRate)
+			.build();
+	}
+}

--- a/src/main/java/com/coniv/mait/web/statistic/controller/CategoryStatisticController.java
+++ b/src/main/java/com/coniv/mait/web/statistic/controller/CategoryStatisticController.java
@@ -1,0 +1,50 @@
+package com.coniv.mait.web.statistic.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coniv.mait.domain.statistic.service.CategoryStatisticService;
+import com.coniv.mait.global.auth.model.MaitUser;
+import com.coniv.mait.global.response.ApiResponse;
+import com.coniv.mait.web.statistic.dto.CategoryCorrectRateApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "카테고리 통계 조회 API")
+@RestController
+@RequestMapping("/api/v1/teams/{teamId}/categories")
+@RequiredArgsConstructor
+public class CategoryStatisticController {
+
+	private final CategoryStatisticService categoryStatisticService;
+
+	@Operation(summary = "카테고리별 정답률 조회 API",
+		description = "카테고리에 속한 종료된 문제 셋들의 모든 문제를 통째로 모아 본인 정답률과 전체 평균 정답률(첫 제출 기준)을 조회한다.")
+	@GetMapping("/{categoryId}/correct-rate")
+	public ResponseEntity<ApiResponse<CategoryCorrectRateApiResponse>> getCategoryCorrectRate(
+		@AuthenticationPrincipal MaitUser user, @PathVariable Long teamId, @PathVariable Long categoryId) {
+		CategoryCorrectRateApiResponse response = CategoryCorrectRateApiResponse.from(
+			categoryStatisticService.getCategoryCorrectRate(user, teamId, categoryId));
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@Operation(summary = "팀 카테고리별 정답률 랭킹 조회 API",
+		description = "팀에 속한 모든 카테고리의 본인 정답률을 높은 순으로 조회한다. 미응시 카테고리는 정답률 null로 맨 뒤에 위치한다.")
+	@GetMapping("/correct-rates")
+	public ResponseEntity<ApiResponse<List<CategoryCorrectRateApiResponse>>> getCategoryCorrectRates(
+		@AuthenticationPrincipal MaitUser user, @PathVariable Long teamId) {
+		List<CategoryCorrectRateApiResponse> response = categoryStatisticService.getCategoryCorrectRates(user, teamId)
+			.stream()
+			.map(CategoryCorrectRateApiResponse::from)
+			.toList();
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+}

--- a/src/main/java/com/coniv/mait/web/statistic/dto/CategoryCorrectRateApiResponse.java
+++ b/src/main/java/com/coniv/mait/web/statistic/dto/CategoryCorrectRateApiResponse.java
@@ -1,0 +1,35 @@
+package com.coniv.mait.web.statistic.dto;
+
+import com.coniv.mait.domain.statistic.service.dto.CategoryCorrectRateDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record CategoryCorrectRateApiResponse(
+	@Schema(description = "카테고리 ID", requiredMode = Schema.RequiredMode.REQUIRED)
+	Long categoryId,
+
+	@Schema(description = "카테고리 이름", requiredMode = Schema.RequiredMode.REQUIRED)
+	String categoryName,
+
+	@Schema(description = "정답률 계산 대상 문제 셋 수 (종료된 문제 셋 기준)", requiredMode = Schema.RequiredMode.REQUIRED)
+	int questionSetCount,
+
+	@Schema(description = "내 정답률 (%, 소수 첫째 자리, 풀지 않은 경우 null)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	Double myCorrectRate,
+
+	@Schema(description = "전체 평균 정답률 (%, 소수 첫째 자리)", requiredMode = Schema.RequiredMode.REQUIRED)
+	double averageCorrectRate
+) {
+
+	public static CategoryCorrectRateApiResponse from(final CategoryCorrectRateDto dto) {
+		return CategoryCorrectRateApiResponse.builder()
+			.categoryId(dto.getCategoryId())
+			.categoryName(dto.getCategoryName())
+			.questionSetCount(dto.getQuestionSetCount())
+			.myCorrectRate(dto.getMyCorrectRate())
+			.averageCorrectRate(dto.getAverageCorrectRate())
+			.build();
+	}
+}

--- a/src/test/java/com/coniv/mait/domain/question/service/component/QuestionSetReaderTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/component/QuestionSetReaderTest.java
@@ -1,9 +1,11 @@
 package com.coniv.mait.domain.question.service.component;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,9 +14,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.coniv.mait.domain.question.entity.QuestionEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
 import com.coniv.mait.domain.question.enums.QuestionSetStatus;
+import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +32,12 @@ class QuestionSetReaderTest {
 
 	@Mock
 	private QuestionSetEntityRepository questionSetEntityRepository;
+
+	@Mock
+	private QuestionEntityRepository questionEntityRepository;
+
+	@Mock
+	private QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
 
 	@Test
 	@DisplayName("지정한 풀이 모드이면서 AFTER 또는 REVIEW 상태인 문제셋 목록을 반환한다")
@@ -66,5 +79,93 @@ class QuestionSetReaderTest {
 
 		// then
 		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("getFinishedQuestionSetsByCategoryId - 카테고리별로 연결된 종료 문제 셋만 묶어 반환한다")
+	void getFinishedQuestionSetsByCategoryId_Success() {
+		// given
+		QuestionSetCategoryEntity category1 = mockCategory(1L);
+		QuestionSetCategoryEntity category2 = mockCategory(2L);
+
+		// category1 → 문제 셋 10(종료), 11(미종료) / category2 → 문제 셋 20(종료)
+		when(questionSetCategoryLinkEntityRepository.findAllByCategoryIdIn(List.of(1L, 2L))).thenReturn(List.of(
+			QuestionSetCategoryLinkEntity.of(10L, 1L),
+			QuestionSetCategoryLinkEntity.of(11L, 1L),
+			QuestionSetCategoryLinkEntity.of(20L, 2L)));
+
+		QuestionSetEntity qs10 = mockQuestionSet(10L);
+		QuestionSetEntity qs20 = mockQuestionSet(20L);
+		when(questionSetEntityRepository.findAllByIdInAndStatusIn(anyList(),
+			eq(List.of(QuestionSetStatus.AFTER, QuestionSetStatus.REVIEW))))
+			.thenReturn(List.of(qs10, qs20));
+
+		// when
+		Map<Long, List<QuestionSetEntity>> result =
+			questionSetReader.getFinishedQuestionSetsByCategoryId(List.of(category1, category2));
+
+		// then
+		assertThat(result).hasSize(2);
+		assertThat(result.get(1L)).containsExactly(qs10);
+		assertThat(result.get(2L)).containsExactly(qs20);
+	}
+
+	@Test
+	@DisplayName("getFinishedQuestionSetsByCategoryId - 카테고리가 없으면 빈 맵을 반환하고 조회하지 않는다")
+	void getFinishedQuestionSetsByCategoryId_emptyCategories() {
+		// when
+		Map<Long, List<QuestionSetEntity>> result = questionSetReader.getFinishedQuestionSetsByCategoryId(List.of());
+
+		// then
+		assertThat(result).isEmpty();
+		verify(questionSetCategoryLinkEntityRepository, never()).findAllByCategoryIdIn(any());
+	}
+
+	@Test
+	@DisplayName("getQuestionsByQuestionSetId - 문제를 문제 셋 ID별로 묶어 반환한다")
+	void getQuestionsByQuestionSetId_Success() {
+		// given
+		QuestionEntity q1 = mockQuestion(10L);
+		QuestionEntity q2 = mockQuestion(10L);
+		QuestionEntity q3 = mockQuestion(20L);
+		when(questionEntityRepository.findAllByQuestionSetIdIn(List.of(10L, 20L))).thenReturn(List.of(q1, q2, q3));
+
+		// when
+		Map<Long, List<QuestionEntity>> result = questionSetReader.getQuestionsByQuestionSetId(List.of(10L, 20L));
+
+		// then
+		assertThat(result.get(10L)).containsExactly(q1, q2);
+		assertThat(result.get(20L)).containsExactly(q3);
+	}
+
+	@Test
+	@DisplayName("getQuestionsByQuestionSetId - 문제 셋 ID가 없으면 빈 맵을 반환한다")
+	void getQuestionsByQuestionSetId_empty() {
+		// when
+		Map<Long, List<QuestionEntity>> result = questionSetReader.getQuestionsByQuestionSetId(List.of());
+
+		// then
+		assertThat(result).isEmpty();
+		verify(questionEntityRepository, never()).findAllByQuestionSetIdIn(anyList());
+	}
+
+	private QuestionSetCategoryEntity mockCategory(final Long id) {
+		QuestionSetCategoryEntity category = mock(QuestionSetCategoryEntity.class);
+		when(category.getId()).thenReturn(id);
+		return category;
+	}
+
+	private QuestionSetEntity mockQuestionSet(final Long id) {
+		QuestionSetEntity questionSet = mock(QuestionSetEntity.class);
+		lenient().when(questionSet.getId()).thenReturn(id);
+		return questionSet;
+	}
+
+	private QuestionEntity mockQuestion(final Long questionSetId) {
+		QuestionEntity question = mock(QuestionEntity.class);
+		QuestionSetEntity questionSet = mock(QuestionSetEntity.class);
+		when(questionSet.getId()).thenReturn(questionSetId);
+		when(question.getQuestionSet()).thenReturn(questionSet);
+		return question;
 	}
 }

--- a/src/test/java/com/coniv/mait/domain/statistic/service/CategoryStatisticServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/statistic/service/CategoryStatisticServiceTest.java
@@ -1,0 +1,244 @@
+package com.coniv.mait.domain.statistic.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.coniv.mait.domain.question.entity.QuestionEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetEntity;
+import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
+import com.coniv.mait.domain.question.service.component.QuestionSetReader;
+import com.coniv.mait.domain.statistic.service.component.QuestionSetStatisticCalculator;
+import com.coniv.mait.domain.statistic.service.dto.CategoryCorrectRateDto;
+import com.coniv.mait.domain.user.exception.UserRoleException;
+import com.coniv.mait.domain.user.service.component.TeamRoleValidator;
+import com.coniv.mait.global.auth.model.MaitUser;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryStatisticServiceTest {
+
+	private static final Long USER_ID = 1L;
+	private static final Long TEAM_ID = 100L;
+	private static final Long CATEGORY_ID = 10L;
+	private static final MaitUser MAIT_USER = MaitUser.builder().id(USER_ID).build();
+
+	@InjectMocks
+	private CategoryStatisticService categoryStatisticService;
+
+	@Mock
+	private QuestionSetCategoryEntityRepository questionSetCategoryEntityRepository;
+
+	@Mock
+	private QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
+
+	@Mock
+	private QuestionSetReader questionSetReader;
+
+	@Mock
+	private QuestionEntityRepository questionEntityRepository;
+
+	@Mock
+	private TeamRoleValidator teamRoleValidator;
+
+	@Mock
+	private QuestionSetStatisticCalculator questionSetStatisticCalculator;
+
+	@Test
+	@DisplayName("getCategoryCorrectRates - 카테고리별 내 정답률을 높은 순으로 정렬하고, 미응시 카테고리는 null로 맨 뒤에 둔다")
+	void getCategoryCorrectRates_success() {
+		// given
+		QuestionSetCategoryEntity java = mockCategory(1L, "Java");
+		QuestionSetCategoryEntity spring = mockCategory(2L, "Spring");
+		QuestionSetCategoryEntity db = mockCategory(3L, "DB");
+		when(questionSetCategoryEntityRepository.findAllByTeamIdAndDeletedAtIsNullOrderByCreatedAtAsc(TEAM_ID))
+			.thenReturn(List.of(java, spring, db));
+
+		// Java: 종료 셋 2개, Spring: 1개, DB: 0개
+		Map<Long, List<QuestionSetEntity>> finishedByCategory = Map.of(
+			1L, List.of(mockQuestionSet(101L), mockQuestionSet(102L)),
+			2L, List.of(mockQuestionSet(201L)),
+			3L, List.of());
+		when(questionSetReader.getFinishedQuestionSetsByCategoryId(anyList())).thenReturn(finishedByCategory);
+		when(questionSetReader.getQuestionsByQuestionSetId(any())).thenReturn(Map.of());
+
+		Map<Long, Double> myRates = new HashMap<>();
+		myRates.put(1L, 80.0);
+		myRates.put(2L, 90.0);
+		myRates.put(3L, null);
+		when(questionSetStatisticCalculator.calculateUserCorrectRates(eq(USER_ID), anyMap())).thenReturn(myRates);
+		when(questionSetStatisticCalculator.calculateOverallCorrectRates(anyMap())).thenReturn(Map.of(
+			1L, 70.0, 2L, 60.0, 3L, 0.0));
+
+		// when
+		List<CategoryCorrectRateDto> result = categoryStatisticService.getCategoryCorrectRates(MAIT_USER, TEAM_ID);
+
+		// then
+		assertThat(result).hasSize(3);
+		// 내 정답률 내림차순: Spring(90.0) > Java(80.0) > DB(null)
+		assertThat(result.get(0).getCategoryId()).isEqualTo(2L);
+		assertThat(result.get(0).getCategoryName()).isEqualTo("Spring");
+		assertThat(result.get(0).getQuestionSetCount()).isEqualTo(1);
+		assertThat(result.get(0).getMyCorrectRate()).isEqualTo(90.0);
+		assertThat(result.get(0).getAverageCorrectRate()).isEqualTo(60.0);
+
+		assertThat(result.get(1).getCategoryId()).isEqualTo(1L);
+		assertThat(result.get(1).getQuestionSetCount()).isEqualTo(2);
+		assertThat(result.get(1).getMyCorrectRate()).isEqualTo(80.0);
+
+		assertThat(result.get(2).getCategoryId()).isEqualTo(3L);
+		assertThat(result.get(2).getQuestionSetCount()).isEqualTo(0);
+		assertThat(result.get(2).getMyCorrectRate()).isNull();
+		assertThat(result.get(2).getAverageCorrectRate()).isEqualTo(0.0);
+	}
+
+	@Test
+	@DisplayName("getCategoryCorrectRates - 내 정답률이 동률이면 카테고리 이름 오름차순으로 정렬한다")
+	void getCategoryCorrectRates_sameRate_sortedByNameAsc() {
+		// given
+		QuestionSetCategoryEntity banana = mockCategory(1L, "Banana");
+		QuestionSetCategoryEntity apple = mockCategory(2L, "Apple");
+		when(questionSetCategoryEntityRepository.findAllByTeamIdAndDeletedAtIsNullOrderByCreatedAtAsc(TEAM_ID))
+			.thenReturn(List.of(banana, apple));
+
+		Map<Long, List<QuestionSetEntity>> finishedByCategory = Map.of(
+			1L, List.of(mockQuestionSet(101L)),
+			2L, List.of(mockQuestionSet(201L)));
+		when(questionSetReader.getFinishedQuestionSetsByCategoryId(anyList())).thenReturn(finishedByCategory);
+		when(questionSetReader.getQuestionsByQuestionSetId(any())).thenReturn(Map.of());
+		when(questionSetStatisticCalculator.calculateUserCorrectRates(eq(USER_ID), anyMap()))
+			.thenReturn(Map.of(1L, 50.0, 2L, 50.0));
+		when(questionSetStatisticCalculator.calculateOverallCorrectRates(anyMap()))
+			.thenReturn(Map.of(1L, 50.0, 2L, 50.0));
+
+		// when
+		List<CategoryCorrectRateDto> result = categoryStatisticService.getCategoryCorrectRates(MAIT_USER, TEAM_ID);
+
+		// then
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).getCategoryName()).isEqualTo("Apple");
+		assertThat(result.get(1).getCategoryName()).isEqualTo("Banana");
+	}
+
+	@Test
+	@DisplayName("getCategoryCorrectRates - 팀에 카테고리가 없으면 빈 목록을 반환하고 종료 셋을 조회하지 않는다")
+	void getCategoryCorrectRates_emptyCategories_returnsEmpty() {
+		// given
+		when(questionSetCategoryEntityRepository.findAllByTeamIdAndDeletedAtIsNullOrderByCreatedAtAsc(TEAM_ID))
+			.thenReturn(List.of());
+
+		// when
+		List<CategoryCorrectRateDto> result = categoryStatisticService.getCategoryCorrectRates(MAIT_USER, TEAM_ID);
+
+		// then
+		assertThat(result).isEmpty();
+		verify(questionSetReader, never()).getFinishedQuestionSetsByCategoryId(any());
+	}
+
+	@Test
+	@DisplayName("getCategoryCorrectRates - 팀 풀이 권한이 없으면 UserRoleException이 발생한다")
+	void getCategoryCorrectRates_noAuthority_throwsUserRoleException() {
+		// given
+		doThrow(new UserRoleException("해당 문제를 풀 수 있는 권한이 없습니다."))
+			.when(teamRoleValidator).checkHasSolveQuestionAuthorityInTeam(TEAM_ID, USER_ID);
+
+		// when & then
+		assertThatThrownBy(() -> categoryStatisticService.getCategoryCorrectRates(MAIT_USER, TEAM_ID))
+			.isInstanceOf(UserRoleException.class)
+			.hasMessage("해당 문제를 풀 수 있는 권한이 없습니다.");
+	}
+
+	@Test
+	@DisplayName("getCategoryCorrectRate - 카테고리의 종료 셋 문제를 모아 내 정답률과 평균 정답률을 반환한다")
+	void getCategoryCorrectRate_success() {
+		// given
+		QuestionSetCategoryEntity category = mockCategory(CATEGORY_ID, "Java");
+		when(questionSetCategoryEntityRepository.findByIdAndTeamIdAndDeletedAtIsNull(CATEGORY_ID, TEAM_ID))
+			.thenReturn(Optional.of(category));
+		when(questionSetCategoryLinkEntityRepository.findAllByCategoryId(CATEGORY_ID))
+			.thenReturn(List.of(QuestionSetCategoryLinkEntity.of(101L, CATEGORY_ID)));
+		QuestionSetEntity finishedSet = mockQuestionSet(101L);
+		when(questionSetReader.getFinishedQuestionSets(List.of(101L))).thenReturn(List.of(finishedSet));
+
+		List<QuestionEntity> questions = List.of(mock(QuestionEntity.class));
+		when(questionEntityRepository.findAllByQuestionSetIdIn(List.of(101L))).thenReturn(questions);
+		when(questionSetStatisticCalculator.calculateUserCorrectRate(USER_ID, questions)).thenReturn(80.0);
+		when(questionSetStatisticCalculator.calculateOverallCorrectRate(questions)).thenReturn(70.0);
+
+		// when
+		CategoryCorrectRateDto result =
+			categoryStatisticService.getCategoryCorrectRate(MAIT_USER, TEAM_ID, CATEGORY_ID);
+
+		// then
+		assertThat(result.getCategoryId()).isEqualTo(CATEGORY_ID);
+		assertThat(result.getCategoryName()).isEqualTo("Java");
+		assertThat(result.getQuestionSetCount()).isEqualTo(1);
+		assertThat(result.getMyCorrectRate()).isEqualTo(80.0);
+		assertThat(result.getAverageCorrectRate()).isEqualTo(70.0);
+	}
+
+	@Test
+	@DisplayName("getCategoryCorrectRate - 종료된 문제 셋이 없으면 0건/정답률 null을 반환하고 정답률 계산을 하지 않는다")
+	void getCategoryCorrectRate_noFinishedSets_returnsEmptyStat() {
+		// given
+		QuestionSetCategoryEntity category = mockCategory(CATEGORY_ID, "Java");
+		when(questionSetCategoryEntityRepository.findByIdAndTeamIdAndDeletedAtIsNull(CATEGORY_ID, TEAM_ID))
+			.thenReturn(Optional.of(category));
+		when(questionSetCategoryLinkEntityRepository.findAllByCategoryId(CATEGORY_ID))
+			.thenReturn(List.of(QuestionSetCategoryLinkEntity.of(101L, CATEGORY_ID)));
+		when(questionSetReader.getFinishedQuestionSets(List.of(101L))).thenReturn(List.of());
+
+		// when
+		CategoryCorrectRateDto result =
+			categoryStatisticService.getCategoryCorrectRate(MAIT_USER, TEAM_ID, CATEGORY_ID);
+
+		// then
+		assertThat(result.getQuestionSetCount()).isZero();
+		assertThat(result.getMyCorrectRate()).isNull();
+		assertThat(result.getAverageCorrectRate()).isEqualTo(0.0);
+		verify(questionSetStatisticCalculator, never()).calculateUserCorrectRate(anyLong(), anyList());
+	}
+
+	@Test
+	@DisplayName("getCategoryCorrectRate - 팀에 속하지 않은 카테고리이면 EntityNotFoundException이 발생한다")
+	void getCategoryCorrectRate_categoryNotFound_throwsEntityNotFoundException() {
+		// given
+		when(questionSetCategoryEntityRepository.findByIdAndTeamIdAndDeletedAtIsNull(CATEGORY_ID, TEAM_ID))
+			.thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> categoryStatisticService.getCategoryCorrectRate(MAIT_USER, TEAM_ID, CATEGORY_ID))
+			.isInstanceOf(EntityNotFoundException.class)
+			.hasMessage("해당 카테고리를 찾을 수 없습니다.");
+	}
+
+	private QuestionSetCategoryEntity mockCategory(final Long id, final String name) {
+		QuestionSetCategoryEntity category = mock(QuestionSetCategoryEntity.class);
+		lenient().when(category.getId()).thenReturn(id);
+		lenient().when(category.getName()).thenReturn(name);
+		return category;
+	}
+
+	private QuestionSetEntity mockQuestionSet(final Long id) {
+		QuestionSetEntity questionSet = mock(QuestionSetEntity.class);
+		lenient().when(questionSet.getId()).thenReturn(id);
+		return questionSet;
+	}
+}

--- a/src/test/java/com/coniv/mait/web/statistic/controller/CategoryStatisticApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/statistic/controller/CategoryStatisticApiIntegrationTest.java
@@ -1,0 +1,150 @@
+package com.coniv.mait.web.statistic.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.coniv.mait.domain.question.entity.MultipleQuestionEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
+import com.coniv.mait.domain.question.entity.QuestionSetEntity;
+import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
+import com.coniv.mait.domain.question.enums.QuestionSetStatus;
+import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetCategoryLinkEntityRepository;
+import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
+import com.coniv.mait.domain.solve.entity.AnswerSubmitRecordEntity;
+import com.coniv.mait.domain.solve.repository.AnswerSubmitRecordEntityRepository;
+import com.coniv.mait.domain.team.entity.TeamEntity;
+import com.coniv.mait.domain.team.entity.TeamUserEntity;
+import com.coniv.mait.domain.team.repository.TeamEntityRepository;
+import com.coniv.mait.domain.team.repository.TeamUserEntityRepository;
+import com.coniv.mait.domain.user.entity.UserEntity;
+import com.coniv.mait.domain.user.repository.UserEntityRepository;
+import com.coniv.mait.login.WithCustomUser;
+import com.coniv.mait.web.integration.BaseIntegrationTest;
+
+@WithCustomUser
+public class CategoryStatisticApiIntegrationTest extends BaseIntegrationTest {
+
+	@Autowired
+	private UserEntityRepository userEntityRepository;
+
+	@Autowired
+	private TeamEntityRepository teamEntityRepository;
+
+	@Autowired
+	private TeamUserEntityRepository teamUserEntityRepository;
+
+	@Autowired
+	private QuestionSetEntityRepository questionSetEntityRepository;
+
+	@Autowired
+	private QuestionEntityRepository questionEntityRepository;
+
+	@Autowired
+	private QuestionSetCategoryEntityRepository questionSetCategoryEntityRepository;
+
+	@Autowired
+	private QuestionSetCategoryLinkEntityRepository questionSetCategoryLinkEntityRepository;
+
+	@Autowired
+	private AnswerSubmitRecordEntityRepository answerSubmitRecordEntityRepository;
+
+	@BeforeEach
+	void clear() {
+		answerSubmitRecordEntityRepository.deleteAll();
+		questionSetCategoryLinkEntityRepository.deleteAll();
+		questionEntityRepository.deleteAll();
+		questionSetEntityRepository.deleteAll();
+		questionSetCategoryEntityRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("팀 카테고리별 내 정답률을 높은 순으로 조회하고, 종료 셋이 없는 카테고리는 정답률 null로 맨 뒤에 둔다")
+	void getCategoryCorrectRates_Success() throws Exception {
+		// given
+		UserEntity user = userEntityRepository.findByEmail("user@example.com").orElseThrow();
+		TeamEntity team = teamEntityRepository.save(TeamEntity.ofGroup("categoryStatTeam", user.getId()));
+		teamUserEntityRepository.save(TeamUserEntity.createPlayerUser(user, team));
+
+		QuestionSetCategoryEntity javaCategory =
+			questionSetCategoryEntityRepository.save(QuestionSetCategoryEntity.of(team.getId(), "Java"));
+		QuestionSetCategoryEntity springCategory =
+			questionSetCategoryEntityRepository.save(QuestionSetCategoryEntity.of(team.getId(), "Spring"));
+		QuestionSetCategoryEntity dbCategory =
+			questionSetCategoryEntityRepository.save(QuestionSetCategoryEntity.of(team.getId(), "DB"));
+
+		// Java: 종료 셋, 두 문제 모두 정답 → 내 정답률 100.0
+		QuestionSetEntity javaSet = saveQuestionSet(team.getId(), "자바", QuestionSetStatus.AFTER);
+		MultipleQuestionEntity jq1 = saveQuestion(javaSet, 1L, "a");
+		MultipleQuestionEntity jq2 = saveQuestion(javaSet, 2L, "b");
+		saveSubmit(user.getId(), jq1.getId(), true);
+		saveSubmit(user.getId(), jq2.getId(), true);
+		link(javaSet.getId(), javaCategory.getId());
+
+		// Spring: 종료 셋, 한 문제만 정답 → 내 정답률 50.0
+		QuestionSetEntity springSet = saveQuestionSet(team.getId(), "스프링", QuestionSetStatus.AFTER);
+		MultipleQuestionEntity sq1 = saveQuestion(springSet, 1L, "a");
+		MultipleQuestionEntity sq2 = saveQuestion(springSet, 2L, "b");
+		saveSubmit(user.getId(), sq1.getId(), true);
+		saveSubmit(user.getId(), sq2.getId(), false);
+		link(springSet.getId(), springCategory.getId());
+
+		// DB: 진행 중 셋만 연결 → 종료 셋 없음
+		QuestionSetEntity ongoingSet = saveQuestionSet(team.getId(), "디비", QuestionSetStatus.ONGOING);
+		link(ongoingSet.getId(), dbCategory.getId());
+
+		// when & then
+		mockMvc.perform(
+				get("/api/v1/teams/{teamId}/categories/correct-rates", team.getId()))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.isSuccess").value(true),
+				jsonPath("$.data.length()").value(3),
+				jsonPath("$.data[0].categoryName").value("Java"),
+				jsonPath("$.data[0].questionSetCount").value(1),
+				jsonPath("$.data[0].myCorrectRate").value(100.0),
+				jsonPath("$.data[0].averageCorrectRate").value(100.0),
+				jsonPath("$.data[1].categoryName").value("Spring"),
+				jsonPath("$.data[1].questionSetCount").value(1),
+				jsonPath("$.data[1].myCorrectRate").value(50.0),
+				jsonPath("$.data[2].categoryName").value("DB"),
+				jsonPath("$.data[2].questionSetCount").value(0),
+				jsonPath("$.data[2].myCorrectRate").doesNotExist(),
+				jsonPath("$.data[2].averageCorrectRate").value(0.0));
+	}
+
+	private QuestionSetEntity saveQuestionSet(final Long teamId, final String title, final QuestionSetStatus status) {
+		return questionSetEntityRepository.save(QuestionSetEntity.builder()
+			.teamId(teamId)
+			.title(title)
+			.solveMode(QuestionSetSolveMode.LIVE_TIME)
+			.status(status)
+			.endTime(LocalDateTime.of(2026, 5, 31, 12, 0))
+			.build());
+	}
+
+	private MultipleQuestionEntity saveQuestion(final QuestionSetEntity questionSet, final Long number,
+		final String lexoRank) {
+		return questionEntityRepository.save(
+			MultipleQuestionEntity.builder().questionSet(questionSet).number(number).lexoRank(lexoRank).build());
+	}
+
+	private void saveSubmit(final Long userId, final Long questionId, final boolean isCorrect) {
+		answerSubmitRecordEntityRepository.save(AnswerSubmitRecordEntity.builder()
+			.userId(userId).questionId(questionId).isCorrect(isCorrect).submitOrder(1L).submittedAnswer("{\"a\":1}")
+			.build());
+	}
+
+	private void link(final Long questionSetId, final Long categoryId) {
+		questionSetCategoryLinkEntityRepository.save(QuestionSetCategoryLinkEntity.of(questionSetId, categoryId));
+	}
+}

--- a/src/test/java/com/coniv/mait/web/statistic/controller/CategoryStatisticControllerTest.java
+++ b/src/test/java/com/coniv/mait/web/statistic/controller/CategoryStatisticControllerTest.java
@@ -1,0 +1,92 @@
+package com.coniv.mait.web.statistic.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.coniv.mait.domain.statistic.service.CategoryStatisticService;
+import com.coniv.mait.domain.statistic.service.dto.CategoryCorrectRateDto;
+import com.coniv.mait.global.filter.JwtAuthorizationFilter;
+import com.coniv.mait.global.interceptor.idempotency.IdempotencyInterceptor;
+
+@WebMvcTest(controllers = CategoryStatisticController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CategoryStatisticControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private CategoryStatisticService categoryStatisticService;
+
+	@MockitoBean
+	private IdempotencyInterceptor idempotencyInterceptor;
+
+	@MockitoBean
+	private JwtAuthorizationFilter jwtAuthorizationFilter;
+
+	@Test
+	@DisplayName("카테고리별 정답률 단건 조회 성공")
+	void getCategoryCorrectRate_Success() throws Exception {
+		// given
+		Long teamId = 1L;
+		Long categoryId = 10L;
+		CategoryCorrectRateDto dto = CategoryCorrectRateDto.builder()
+			.categoryId(categoryId).categoryName("Java")
+			.questionSetCount(2).myCorrectRate(80.0).averageCorrectRate(70.0)
+			.build();
+		given(categoryStatisticService.getCategoryCorrectRate(any(), eq(teamId), eq(categoryId))).willReturn(dto);
+
+		// when & then
+		mockMvc.perform(
+				get("/api/v1/teams/{teamId}/categories/{categoryId}/correct-rate", teamId, categoryId))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.isSuccess").value(true),
+				jsonPath("$.data.categoryId").value(categoryId),
+				jsonPath("$.data.categoryName").value("Java"),
+				jsonPath("$.data.questionSetCount").value(2),
+				jsonPath("$.data.myCorrectRate").value(80.0),
+				jsonPath("$.data.averageCorrectRate").value(70.0));
+	}
+
+	@Test
+	@DisplayName("팀 카테고리별 정답률 랭킹 조회 성공")
+	void getCategoryCorrectRates_Success() throws Exception {
+		// given
+		Long teamId = 1L;
+		List<CategoryCorrectRateDto> ranking = List.of(
+			CategoryCorrectRateDto.builder()
+				.categoryId(2L).categoryName("Spring")
+				.questionSetCount(1).myCorrectRate(90.0).averageCorrectRate(60.0)
+				.build(),
+			CategoryCorrectRateDto.builder()
+				.categoryId(3L).categoryName("DB")
+				.questionSetCount(0).myCorrectRate(null).averageCorrectRate(0.0)
+				.build());
+		given(categoryStatisticService.getCategoryCorrectRates(any(), eq(teamId))).willReturn(ranking);
+
+		// when & then
+		mockMvc.perform(
+				get("/api/v1/teams/{teamId}/categories/correct-rates", teamId))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.isSuccess").value(true),
+				jsonPath("$.data.length()").value(2),
+				jsonPath("$.data[0].categoryId").value(2),
+				jsonPath("$.data[0].myCorrectRate").value(90.0),
+				jsonPath("$.data[1].categoryId").value(3),
+				jsonPath("$.data[1].myCorrectRate").doesNotExist());
+	}
+}


### PR DESCRIPTION
### Motivation

<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

풀이결과 대시보드에서 유저의 카테고리별 정답률을 노출해야한다.

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)

<!-- 테스트 결과를 보여주세요. -->

- [x] 단위테스트를 작성했는지
- [x] 컨트롤러 단위테스트를 작성했는지
- [x] 통합테스트를 작성했는지

### SQL

<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->

```sql

```
