### PR TITLE
[EDU-595] 제작 중 문제셋이 MAKING 모드로 조회되도록 수정

### DIFF
--- a/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetEntity.java
+++ b/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetEntity.java
@@ -65,7 +65,7 @@ public class QuestionSetEntity extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "status")
 	@Builder.Default
-	private QuestionSetStatus status = QuestionSetStatus.BEFORE;
+	private QuestionSetStatus status = QuestionSetStatus.MAKING;
 
 	private String difficulty;
 
@@ -183,12 +183,12 @@ public class QuestionSetEntity extends BaseTimeEntity {
 	}
 
 	public DeliveryMode getDisplayMode() {
-		if (canReview()) {
-			return DeliveryMode.REVIEW;
+		if (status == QuestionSetStatus.MAKING) {
+			return DeliveryMode.MAKING;
 		}
 
-		if (solveMode == null) {
-			return DeliveryMode.MAKING;
+		if (canReview()) {
+			return DeliveryMode.REVIEW;
 		}
 
 		return DeliveryMode.from(solveMode);

--- a/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetEntity.java
+++ b/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetEntity.java
@@ -183,14 +183,6 @@ public class QuestionSetEntity extends BaseTimeEntity {
 	}
 
 	public DeliveryMode getDisplayMode() {
-		if (status == QuestionSetStatus.MAKING) {
-			return DeliveryMode.MAKING;
-		}
-
-		if (canReview()) {
-			return DeliveryMode.REVIEW;
-		}
-
-		return DeliveryMode.from(solveMode);
+		return DeliveryMode.resolve(status, solveMode);
 	}
 }

--- a/src/main/java/com/coniv/mait/domain/question/enums/DeliveryMode.java
+++ b/src/main/java/com/coniv/mait/domain/question/enums/DeliveryMode.java
@@ -42,4 +42,16 @@ public enum DeliveryMode {
 			case STUDY -> DeliveryMode.STUDY;
 		};
 	}
+
+	public static DeliveryMode resolve(QuestionSetStatus status, QuestionSetSolveMode solveMode) {
+		if (status == QuestionSetStatus.MAKING || solveMode == null) {
+			return MAKING;
+		}
+
+		if (status == QuestionSetStatus.REVIEW) {
+			return REVIEW;
+		}
+
+		return from(solveMode);
+	}
 }

--- a/src/main/java/com/coniv/mait/domain/question/enums/QuestionSetStatus.java
+++ b/src/main/java/com/coniv/mait/domain/question/enums/QuestionSetStatus.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum QuestionSetStatus {
+	MAKING("제작 중"),
 	BEFORE("풀이 전"),
 	ONGOING("풀이 중"),
 	AFTER("풀이 완료"),

--- a/src/main/java/com/coniv/mait/web/question/dto/QuestionSetApiResponse.java
+++ b/src/main/java/com/coniv/mait/web/question/dto/QuestionSetApiResponse.java
@@ -55,7 +55,7 @@ public record QuestionSetApiResponse(
 			.subject(questionSetDto.getTitle())
 			.creationType(questionSetDto.getCreationType())
 			.visibility(questionSetDto.getVisibility())
-			.deliveryMode(resolveDeliveryMode(questionSetDto.getStatus(), questionSetDto.getSolveMode()))
+			.deliveryMode(DeliveryMode.resolve(questionSetDto.getStatus(), questionSetDto.getSolveMode()))
 			.solveMode(questionSetDto.getSolveMode())
 			.status(questionSetDto.getStatus())
 			.teamId(questionSetDto.getTeamId())
@@ -64,18 +64,5 @@ public record QuestionSetApiResponse(
 			.categories(questionSetDto.getCategories() == null ? List.of() : questionSetDto.getCategories())
 			.updatedAt(questionSetDto.getUpdatedAt())
 			.build();
-	}
-
-	private static DeliveryMode resolveDeliveryMode(final QuestionSetStatus status,
-		final QuestionSetSolveMode solveMode) {
-		if (status == QuestionSetStatus.REVIEW) {
-			return DeliveryMode.REVIEW;
-		}
-
-		if (solveMode == null) {
-			return DeliveryMode.MAKING;
-		}
-
-		return DeliveryMode.from(solveMode);
 	}
 }

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
@@ -359,6 +359,27 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("문제 셋 단건 조회 API 성공 테스트 - 풀이방식이 지정된 제작 중 문제 셋은 deliveryMode가 MAKING이다")
+	void getQuestionSetApiSuccess_MakingWithSolveMode_ReturnsMakingDeliveryMode() throws Exception {
+		// given
+		QuestionSetEntity questionSet = questionSetEntityRepository.save(
+			QuestionSetEntity.builder()
+				.title("제작 중 실시간 문제")
+				.status(QuestionSetStatus.MAKING)
+				.solveMode(QuestionSetSolveMode.LIVE_TIME)
+				.build());
+
+		// when & then
+		mockMvc.perform(get("/api/v1/question-sets/{questionSetId}", questionSet.getId())
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.data.id").value(questionSet.getId()),
+				jsonPath("$.data.deliveryMode").value(DeliveryMode.MAKING.name()),
+				jsonPath("$.data.solveMode").value(QuestionSetSolveMode.LIVE_TIME.name()));
+	}
+
+	@Test
 	@DisplayName("문제 셋 최종 저장 API 성공 테스트")
 	void updateQuestionSetsApiSuccess() throws Exception {
 		// given

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
@@ -154,6 +154,36 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("문제 셋 목록 조회 API 성공 테스트 - 풀이방식이 지정된 제작 중 문제 셋도 MAKING 모드로 조회된다")
+	void getQuestionSetsApiSuccess_MakingMode_WithSolveModeAssigned() throws Exception {
+		// given
+		UserEntity currentUser = userEntityRepository.findByEmail("user@example.com").orElseThrow();
+		TeamEntity team = teamEntityRepository.save(TeamEntity.ofGroup("코니브", 1L));
+		teamUserEntityRepository.save(TeamUserEntity.createTeamUser(currentUser, team, TeamUserRole.MAKER));
+
+		// 생성 시점에 solveMode 가 채워졌지만 아직 최종저장하지 않은(MAKING) 문제 셋
+		QuestionSetEntity makingLiveSet = QuestionSetEntity.builder()
+			.title("제작 중 실시간 문제")
+			.teamId(team.getId())
+			.status(QuestionSetStatus.MAKING)
+			.solveMode(QuestionSetSolveMode.LIVE_TIME)
+			.build();
+		questionSetEntityRepository.save(makingLiveSet);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/question-sets")
+				.param("teamId", String.valueOf(team.getId()))
+				.param("mode", DeliveryMode.MAKING.name())
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.data.mode").value("MAKING"),
+				jsonPath("$.data.content.questionSets").isArray(),
+				jsonPath("$.data.content.questionSets.length()").value(1),
+				jsonPath("$.data.content.questionSets[0].title").value("제작 중 실시간 문제"));
+	}
+
+	@Test
 	@DisplayName("문제 셋 목록 조회 API 성공 테스트 - LIVE_TIME 모드 (Map 구조)")
 	void getQuestionSetsApiSuccess_LiveTimeMode() throws Exception {
 		// given


### PR DESCRIPTION
## 배경
[EDU-595](https://youthing.atlassian.net/browse/EDU-595)

`MAKING` 모드로 문제셋 목록을 조회하면 "제작 중(최종저장 전)" 문제셋이 조회되어야 하는데, 오히려 `LIVE_TIME`/`STUDY` 모드 조회에 섞여 나오는 문제가 있었습니다.

## 원인
- `getDisplayMode()`가 제작 중 여부를 `solveMode == null` 로 판별하고 있었음
- 그러나 [EDU-578](https://youthing.atlassian.net/browse/EDU-578)에서 **생성 시점에 `solveMode`를 필수 입력**으로 바꾸면서, 제작 중 문제셋도 `solveMode != null` 이 되어 `MAKING`이 아닌 `LIVE_TIME`/`STUDY`로 분류됨
- 동일한 분류 로직이 `QuestionSetApiResponse`에도 복제돼 있어 **단건 조회 응답의 `deliveryMode`** 도 같은 버그가 있었음

## 변경 사항
- `QuestionSetStatus`에 `MAKING` 상태 추가, 생성 시 기본 상태로 지정 → 라이프사이클 단계로 "제작 중"을 명시
- `completeQuestionSet`(최종저장) 시 `MAKING → BEFORE`로 전이 (기존 동작 유지)
- 분류 규칙을 `DeliveryMode.resolve(status, solveMode)` 로 **일원화**하고, 엔티티 `getDisplayMode()` 와 단건 조회 응답이 모두 이를 사용하도록 통일 (복제 제거)
- `solveMode == null` 인 구 데이터에 대한 방어 로직 유지

## 데이터 영향
- `QuestionSetStatus`는 `EnumType.STRING`(VARCHAR) 이라 **DDL 마이그레이션 불필요**
- 배포 전부터 존재하던 "제작 중" row는 `status=BEFORE`로 남아 있어 기존 데이터에 한해 여전히 오분류될 수 있음. 필요 시 아래로 규모 확인 후 보정:
  ```sql
  SELECT count(*) FROM question_sets WHERE status='BEFORE' AND solve_mode IS NOT NULL;
  ```

## 테스트
- 풀이방식이 지정된 제작 중 문제셋이 `MAKING` 목록 조회에 포함되는지 (통합)
- 제작 중 문제셋 단건 조회 시 `deliveryMode`가 `MAKING`인지 (통합)

[EDU-595]: https://youthing.atlassian.net/browse/EDU-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDU-578]: https://youthing.atlassian.net/browse/EDU-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ