### PR TITLE
[EDU-596] 문제 셋 단건 응답에 유형별 문제 개수·instruction 추가

### DIFF
--- a/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetEntity.java
+++ b/src/main/java/com/coniv/mait/domain/question/entity/QuestionSetEntity.java
@@ -69,6 +69,9 @@ public class QuestionSetEntity extends BaseTimeEntity {
 
 	private String difficulty;
 
+	@Column(columnDefinition = "TEXT")
+	private String instruction;
+
 	@Builder.Default
 	private boolean advancementSelected = false;
 

--- a/src/main/java/com/coniv/mait/domain/question/service/QuestionSetService.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/QuestionSetService.java
@@ -1,7 +1,10 @@
 package com.coniv.mait.domain.question.service;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +17,7 @@ import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
 import com.coniv.mait.domain.question.enums.QuestionSetVisibility;
+import com.coniv.mait.domain.question.enums.QuestionType;
 import com.coniv.mait.domain.question.event.AiQuestionGenerationRequestedEvent;
 import com.coniv.mait.domain.question.exception.QuestionSetStatusException;
 import com.coniv.mait.domain.question.exception.code.QuestionSetStatusExceptionCode;
@@ -21,9 +25,11 @@ import com.coniv.mait.domain.question.repository.AiRequestStatusManager;
 import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
 import com.coniv.mait.domain.question.service.component.QuestionChecker;
+import com.coniv.mait.domain.question.service.component.QuestionSetReader;
 import com.coniv.mait.domain.question.service.dto.QuestionCount;
 import com.coniv.mait.domain.question.service.dto.QuestionSetCategoryDto;
 import com.coniv.mait.domain.question.service.dto.QuestionSetDto;
+import com.coniv.mait.domain.question.service.dto.QuestionTypeCount;
 import com.coniv.mait.domain.question.service.dto.QuestionValidateDto;
 import com.coniv.mait.domain.team.entity.TeamEntity;
 import com.coniv.mait.domain.team.enums.TeamType;
@@ -58,6 +64,8 @@ public class QuestionSetService {
 
 	private final TeamReader teamReader;
 
+	private final QuestionSetReader questionSetReader;
+
 	private final QuestionSetMaterialService questionSetMaterialService;
 
 	private final AiRequestStatusManager aiRequestStatusManager;
@@ -75,6 +83,7 @@ public class QuestionSetService {
 			.creationType(questionSetDto.getCreationType())
 			.teamId(questionSetDto.getTeamId())
 			.difficulty(difficulty)
+			.instruction(instruction)
 			.solveMode(questionSetDto.getSolveMode())
 			.visibility(questionSetDto.getVisibility())
 			.creatorId(userId)
@@ -139,15 +148,24 @@ public class QuestionSetService {
 	}
 
 	public QuestionSetDto getQuestionSet(final Long questionSetId, final MaitUser maitUser) {
-		final QuestionSetEntity questionSetEntity = questionSetEntityRepository.findById(questionSetId)
-			.orElseThrow(() -> new IllegalArgumentException("Question set not found"));
+		final QuestionSetEntity questionSetEntity = questionSetReader.getQuestionSet(questionSetId);
 
-		long questionCount = questionEntityRepository.countByQuestionSetId(questionSetEntity.getId());
+		List<QuestionEntity> questions = questionEntityRepository.findAllByQuestionSetId(questionSetEntity.getId());
+		List<QuestionTypeCount> questionTypeCounts = countByType(questions);
 
 		List<QuestionSetCategoryDto> categories =
 			questionSetCategoryService.getCategoriesByQuestionSetId(questionSetEntity.getId());
 
-		return QuestionSetDto.of(questionSetEntity, questionCount, categories);
+		return QuestionSetDto.of(questionSetEntity, questions.size(), categories, questionTypeCounts);
+	}
+
+	private List<QuestionTypeCount> countByType(final List<QuestionEntity> questions) {
+		Map<QuestionType, Long> countByType = questions.stream()
+			.collect(Collectors.groupingBy(QuestionEntity::getType, Collectors.counting()));
+
+		return Arrays.stream(QuestionType.values())
+			.map(type -> QuestionTypeCount.of(type, countByType.getOrDefault(type, 0L)))
+			.toList();
 	}
 
 	@Transactional

--- a/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetDto.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionSetDto.java
@@ -31,8 +31,10 @@ public class QuestionSetDto {
 	private Long teamId;
 	private Long questionCount;
 	private String difficulty;
+	private String instruction;
 	private List<MaterialDto> materials;
 	private List<QuestionSetCategoryDto> categories;
+	private List<QuestionTypeCount> questionTypeCounts;
 	private LocalDateTime updatedAt;
 
 	public static QuestionSetDto from(final QuestionSetEntity questionSetEntity) {
@@ -45,13 +47,14 @@ public class QuestionSetDto {
 			.status(questionSetEntity.getStatus())
 			.teamId(questionSetEntity.getTeamId())
 			.difficulty(questionSetEntity.getDifficulty())
+			.instruction(questionSetEntity.getInstruction())
 			.updatedAt(questionSetEntity.getModifiedAt())
 			.categories(List.of())
 			.build();
 	}
 
 	public static QuestionSetDto of(QuestionSetEntity questionSetEntity, long questionCount,
-		List<QuestionSetCategoryDto> categories) {
+		List<QuestionSetCategoryDto> categories, List<QuestionTypeCount> questionTypeCounts) {
 		return QuestionSetDto.builder()
 			.id(questionSetEntity.getId())
 			.title(questionSetEntity.getTitle())
@@ -60,10 +63,12 @@ public class QuestionSetDto {
 			.solveMode(questionSetEntity.getSolveMode())
 			.teamId(questionSetEntity.getTeamId())
 			.difficulty(questionSetEntity.getDifficulty())
+			.instruction(questionSetEntity.getInstruction())
 			.status(questionSetEntity.getStatus())
 			.updatedAt(questionSetEntity.getModifiedAt())
 			.questionCount(questionCount)
 			.categories(categories)
+			.questionTypeCounts(questionTypeCounts)
 			.build();
 	}
 

--- a/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionTypeCount.java
+++ b/src/main/java/com/coniv/mait/domain/question/service/dto/QuestionTypeCount.java
@@ -1,0 +1,12 @@
+package com.coniv.mait.domain.question.service.dto;
+
+import com.coniv.mait.domain.question.enums.QuestionType;
+
+public record QuestionTypeCount(
+	QuestionType type,
+	long count
+) {
+	public static QuestionTypeCount of(final QuestionType type, final long count) {
+		return new QuestionTypeCount(type, count);
+	}
+}

--- a/src/main/java/com/coniv/mait/web/question/dto/QuestionSetApiResponse.java
+++ b/src/main/java/com/coniv/mait/web/question/dto/QuestionSetApiResponse.java
@@ -10,6 +10,7 @@ import com.coniv.mait.domain.question.enums.QuestionSetStatus;
 import com.coniv.mait.domain.question.enums.QuestionSetVisibility;
 import com.coniv.mait.domain.question.service.dto.QuestionSetCategoryDto;
 import com.coniv.mait.domain.question.service.dto.QuestionSetDto;
+import com.coniv.mait.domain.question.service.dto.QuestionTypeCount;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -40,8 +41,12 @@ public record QuestionSetApiResponse(
 
 	@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
 	Long questionCount,
+	@Schema(description = "문제 유형별 개수 (전체 유형 포함, 없는 유형은 0)", requiredMode = Schema.RequiredMode.REQUIRED)
+	List<QuestionTypeCount> questionTypeCounts,
 	@Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 	String difficulty,
+	@Schema(description = "문제 셋 보충 설명", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	String instruction,
 	@Schema(description = "문제 셋에 부착된 카테고리 목록", requiredMode = Schema.RequiredMode.REQUIRED)
 	List<QuestionSetCategoryDto> categories,
 	@Schema(requiredMode = Schema.RequiredMode.REQUIRED)
@@ -60,7 +65,10 @@ public record QuestionSetApiResponse(
 			.status(questionSetDto.getStatus())
 			.teamId(questionSetDto.getTeamId())
 			.questionCount(questionSetDto.getQuestionCount())
+			.questionTypeCounts(
+				questionSetDto.getQuestionTypeCounts() == null ? List.of() : questionSetDto.getQuestionTypeCounts())
 			.difficulty(questionSetDto.getDifficulty())
+			.instruction(questionSetDto.getInstruction())
 			.categories(questionSetDto.getCategories() == null ? List.of() : questionSetDto.getCategories())
 			.updatedAt(questionSetDto.getUpdatedAt())
 			.build();

--- a/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/question/service/QuestionSetServiceTest.java
@@ -22,6 +22,7 @@ import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
 import com.coniv.mait.domain.question.enums.QuestionSetStatus;
 import com.coniv.mait.domain.question.enums.QuestionSetVisibility;
+import com.coniv.mait.domain.question.enums.QuestionType;
 import com.coniv.mait.domain.question.enums.QuestionValidationResult;
 import com.coniv.mait.domain.question.event.AiQuestionGenerationRequestedEvent;
 import com.coniv.mait.domain.question.exception.QuestionSetStatusException;
@@ -29,7 +30,9 @@ import com.coniv.mait.domain.question.exception.code.QuestionSetStatusExceptionC
 import com.coniv.mait.domain.question.repository.AiRequestStatusManager;
 import com.coniv.mait.domain.question.repository.QuestionEntityRepository;
 import com.coniv.mait.domain.question.repository.QuestionSetEntityRepository;
+import com.coniv.mait.domain.question.service.component.QuestionSetReader;
 import com.coniv.mait.domain.question.service.dto.QuestionSetDto;
+import com.coniv.mait.domain.question.service.dto.QuestionTypeCount;
 import com.coniv.mait.domain.question.service.dto.QuestionValidateDto;
 import com.coniv.mait.domain.team.entity.TeamEntity;
 import com.coniv.mait.domain.team.service.component.TeamReader;
@@ -68,6 +71,9 @@ class QuestionSetServiceTest {
 
 	@Mock
 	private TeamReader teamReader;
+
+	@Mock
+	private QuestionSetReader questionSetReader;
 
 	@Mock
 	private AiRequestStatusManager aiRequestStatusManager;
@@ -329,10 +335,8 @@ class QuestionSetServiceTest {
 		when(questionSetEntity.getId()).thenReturn(questionSetId);
 		when(questionSetEntity.getTitle()).thenReturn("Test Title");
 
-		when(questionSetEntityRepository.findById(questionSetId))
-			.thenReturn(Optional.of(questionSetEntity));
-		when(questionEntityRepository.countByQuestionSetId(questionSetId))
-			.thenReturn(5L); // 예시로 5개의 문제를 가진다고 가정
+		when(questionSetReader.getQuestionSet(questionSetId)).thenReturn(questionSetEntity);
+		when(questionEntityRepository.findAllByQuestionSetId(questionSetId)).thenReturn(List.of());
 
 		// when
 		QuestionSetDto result = questionSetService.getQuestionSet(questionSetId, user);
@@ -342,7 +346,40 @@ class QuestionSetServiceTest {
 		assertThat(result.getId()).isEqualTo(questionSetId);
 		assertThat(result.getTitle()).isEqualTo("Test Title");
 
-		verify(questionSetEntityRepository, times(1)).findById(questionSetId);
+		verify(questionSetReader, times(1)).getQuestionSet(questionSetId);
+	}
+
+	@Test
+	@DisplayName("문제 셋 단건 조회 테스트 - 유형별 문제 개수를 전체 유형(없는 유형은 0) 기준으로 반환한다")
+	void getQuestionSetTest_ReturnsQuestionTypeCounts() {
+		// given
+		final Long questionSetId = 1L;
+		final MaitUser user = MaitUser.builder().id(USER_ID).build();
+		final QuestionSetEntity questionSetEntity = mock(QuestionSetEntity.class);
+		when(questionSetEntity.getId()).thenReturn(questionSetId);
+
+		final QuestionEntity multiple1 = mock(QuestionEntity.class);
+		final QuestionEntity multiple2 = mock(QuestionEntity.class);
+		final QuestionEntity shortQuestion = mock(QuestionEntity.class);
+		when(multiple1.getType()).thenReturn(QuestionType.MULTIPLE);
+		when(multiple2.getType()).thenReturn(QuestionType.MULTIPLE);
+		when(shortQuestion.getType()).thenReturn(QuestionType.SHORT);
+
+		when(questionSetReader.getQuestionSet(questionSetId)).thenReturn(questionSetEntity);
+		when(questionEntityRepository.findAllByQuestionSetId(questionSetId))
+			.thenReturn(List.of(multiple1, multiple2, shortQuestion));
+
+		// when
+		QuestionSetDto result = questionSetService.getQuestionSet(questionSetId, user);
+
+		// then
+		assertThat(result.getQuestionCount()).isEqualTo(3L);
+		assertThat(result.getQuestionTypeCounts())
+			.containsExactly(
+				QuestionTypeCount.of(QuestionType.SHORT, 1L),
+				QuestionTypeCount.of(QuestionType.MULTIPLE, 2L),
+				QuestionTypeCount.of(QuestionType.ORDERING, 0L),
+				QuestionTypeCount.of(QuestionType.FILL_BLANK, 0L));
 	}
 
 	@Test
@@ -351,15 +388,15 @@ class QuestionSetServiceTest {
 		// given
 		final Long questionSetId = 1L;
 		final MaitUser user = MaitUser.builder().id(USER_ID).build();
-		when(questionSetEntityRepository.findById(questionSetId))
-			.thenReturn(Optional.empty());
+		when(questionSetReader.getQuestionSet(questionSetId))
+			.thenThrow(new EntityNotFoundException(questionSetId + " : 해당 문제 셋을 찾을 수 없습니다."));
 
 		// when & then
 		assertThatThrownBy(() -> questionSetService.getQuestionSet(questionSetId, user))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("Question set not found");
+			.isInstanceOf(EntityNotFoundException.class)
+			.hasMessage(questionSetId + " : 해당 문제 셋을 찾을 수 없습니다.");
 
-		verify(questionSetEntityRepository, times(1)).findById(questionSetId);
+		verify(questionSetReader, times(1)).getQuestionSet(questionSetId);
 	}
 
 	@Test

--- a/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/question/controller/QuestionSetApiIntegrationTest.java
@@ -18,6 +18,7 @@ import com.coniv.mait.domain.question.entity.MultipleQuestionEntity;
 import com.coniv.mait.domain.question.entity.QuestionSetCategoryEntity;
 import com.coniv.mait.domain.question.entity.QuestionSetCategoryLinkEntity;
 import com.coniv.mait.domain.question.entity.QuestionSetEntity;
+import com.coniv.mait.domain.question.entity.ShortQuestionEntity;
 import com.coniv.mait.domain.question.enums.DeliveryMode;
 import com.coniv.mait.domain.question.enums.QuestionSetCreationType;
 import com.coniv.mait.domain.question.enums.QuestionSetSolveMode;
@@ -326,6 +327,41 @@ public class QuestionSetApiIntegrationTest extends BaseIntegrationTest {
 				status().isOk(),
 				jsonPath("$.data.id").value(questionSet.getId()),
 				jsonPath("$.data.title").value(title));
+	}
+
+	@Test
+	@DisplayName("문제 셋 단건 조회 API 성공 테스트 - 유형별 문제 개수와 instruction을 응답에 포함한다")
+	void getQuestionSetApiSuccess_IncludesQuestionTypeCountsAndInstruction() throws Exception {
+		// given
+		QuestionSetEntity questionSet = questionSetEntityRepository.save(
+			QuestionSetEntity.builder()
+				.title("유형별 개수 문제")
+				.instruction("이 문제 셋에 대한 보충 설명")
+				.build());
+
+		questionEntityRepository.save(MultipleQuestionEntity.builder()
+			.questionSet(questionSet).content("객관식 1").number(1L).lexoRank("a").build());
+		questionEntityRepository.save(MultipleQuestionEntity.builder()
+			.questionSet(questionSet).content("객관식 2").number(2L).lexoRank("b").build());
+		questionEntityRepository.save(ShortQuestionEntity.builder()
+			.questionSet(questionSet).content("주관식 1").number(3L).lexoRank("c").answerCount(1).build());
+
+		// when & then
+		mockMvc.perform(get("/api/v1/question-sets/{questionSetId}", questionSet.getId())
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.data.questionCount").value(3),
+				jsonPath("$.data.instruction").value("이 문제 셋에 대한 보충 설명"),
+				jsonPath("$.data.questionTypeCounts.length()").value(4),
+				jsonPath("$.data.questionTypeCounts[0].type").value("SHORT"),
+				jsonPath("$.data.questionTypeCounts[0].count").value(1),
+				jsonPath("$.data.questionTypeCounts[1].type").value("MULTIPLE"),
+				jsonPath("$.data.questionTypeCounts[1].count").value(2),
+				jsonPath("$.data.questionTypeCounts[2].type").value("ORDERING"),
+				jsonPath("$.data.questionTypeCounts[2].count").value(0),
+				jsonPath("$.data.questionTypeCounts[3].type").value("FILL_BLANK"),
+				jsonPath("$.data.questionTypeCounts[3].count").value(0));
 	}
 
 	@Test


### PR DESCRIPTION
## 배경
[EDU-596](https://youthing.atlassian.net/browse/EDU-596)

문제 셋 단건 조회 응답에 **유형별 문제 개수**와 **instruction(보충 설명)** 을 추가합니다.

## 변경 사항
- `QuestionSetEntity`에 `instruction` 컬럼(TEXT) 추가, 생성 시 영속화
  - 기존엔 `instruction`이 AI 생성 요청에만 쓰이고 DB에 저장되지 않았음
- 단건 조회(`getQuestionSet`)에서 문제를 1회 조회해 **전체 유형 기준**(SHORT/MULTIPLE/ORDERING/FILL_BLANK, 없는 유형은 0) 유형별 개수 집계
  - 총개수도 동일 조회 결과(`size()`)로 산출 → 별도 count 쿼리 제거
- 단건 응답 `QuestionSetApiResponse`에 `questionTypeCounts`, `instruction` 필드 추가

## 응답 예시
```json
{
  "questionCount": 3,
  "questionTypeCounts": [
    {"type": "SHORT", "count": 1},
    {"type": "MULTIPLE", "count": 2},
    {"type": "ORDERING", "count": 0},
    {"type": "FILL_BLANK", "count": 0}
  ],
  "instruction": "보충 설명 ...",
  ...
}
```

## DB 마이그레이션 (DDL)
`instruction` 컬럼 추가가 필요합니다 (`ddl-auto: none`).
```sql
ALTER TABLE question_sets ADD COLUMN instruction TEXT NULL;
```

## 테스트
- (단위) 유형별 개수를 전체 유형(없는 유형 0) 기준으로 반환
- (단위) 단건 조회 성공/실패(EntityNotFoundException) — reader 기반으로 갱신
- (통합) 단건 조회 응답에 유형별 개수 + instruction 포함

[EDU-596]: https://youthing.atlassian.net/browse/EDU-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ