### PR TITLE
[EDU-613] 피쳐 테이블 분리 및 이벤트 조회 API

### DIFF
--- a/src/main/java/com/coniv/mait/domain/admin/entity/AnalyticsEventEntity.java
+++ b/src/main/java/com/coniv/mait/domain/admin/entity/AnalyticsEventEntity.java
@@ -4,10 +4,13 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -19,7 +22,7 @@ import lombok.NoArgsConstructor;
 	name = "analytics_event",
 	uniqueConstraints = @UniqueConstraint(
 		name = "uk_analytics_event",
-		columnNames = {"feature_key", "event_name", "user_id", "session_id"}
+		columnNames = {"feature_id", "event_name", "user_id", "session_id"}
 	),
 	indexes = @Index(name = "idx_analytics_event_name_time", columnList = "event_name, occurred_at")
 )
@@ -32,8 +35,9 @@ public class AnalyticsEventEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "feature_key", nullable = false, length = 100)
-	private String featureKey;
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "feature_id", nullable = false)
+	private AnalyticsFeatureEntity feature;
 
 	@Column(name = "event_name", nullable = false, length = 100)
 	private String eventName;
@@ -54,9 +58,9 @@ public class AnalyticsEventEntity {
 	private String metadata;
 
 	@Builder
-	private AnalyticsEventEntity(String featureKey, String eventName, Long userId, String sessionId,
+	private AnalyticsEventEntity(AnalyticsFeatureEntity feature, String eventName, Long userId, String sessionId,
 		int step, LocalDateTime occurredAt, String metadata) {
-		this.featureKey = featureKey;
+		this.feature = feature;
 		this.eventName = eventName;
 		this.userId = userId;
 		this.sessionId = sessionId;

--- a/src/main/java/com/coniv/mait/domain/admin/entity/AnalyticsFeatureEntity.java
+++ b/src/main/java/com/coniv/mait/domain/admin/entity/AnalyticsFeatureEntity.java
@@ -1,0 +1,39 @@
+package com.coniv.mait.domain.admin.entity;
+
+import com.coniv.mait.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Table(
+	name = "analytics_feature",
+	uniqueConstraints = @UniqueConstraint(name = "uk_analytics_feature_key", columnNames = "feature_key")
+)
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnalyticsFeatureEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "feature_key", nullable = false, length = 100)
+	private String featureKey;
+
+	public static AnalyticsFeatureEntity of(final String featureKey) {
+		return AnalyticsFeatureEntity.builder()
+			.featureKey(featureKey)
+			.build();
+	}
+}

--- a/src/main/java/com/coniv/mait/domain/admin/repository/AnalyticsEventRepository.java
+++ b/src/main/java/com/coniv/mait/domain/admin/repository/AnalyticsEventRepository.java
@@ -1,5 +1,7 @@
 package com.coniv.mait.domain.admin.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
@@ -9,4 +11,6 @@ public interface AnalyticsEventRepository extends JpaRepository<AnalyticsEventEn
 
 	boolean existsByFeatureAndEventNameAndUserIdAndSessionId(
 		AnalyticsFeatureEntity feature, String eventName, Long userId, String sessionId);
+
+	List<AnalyticsEventEntity> findAllByFeature(AnalyticsFeatureEntity feature);
 }

--- a/src/main/java/com/coniv/mait/domain/admin/repository/AnalyticsEventRepository.java
+++ b/src/main/java/com/coniv/mait/domain/admin/repository/AnalyticsEventRepository.java
@@ -3,9 +3,10 @@ package com.coniv.mait.domain.admin.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
 
 public interface AnalyticsEventRepository extends JpaRepository<AnalyticsEventEntity, Long> {
 
-	boolean existsByFeatureKeyAndEventNameAndUserIdAndSessionId(
-		String featureKey, String eventName, Long userId, String sessionId);
+	boolean existsByFeatureAndEventNameAndUserIdAndSessionId(
+		AnalyticsFeatureEntity feature, String eventName, Long userId, String sessionId);
 }

--- a/src/main/java/com/coniv/mait/domain/admin/repository/AnalyticsFeatureRepository.java
+++ b/src/main/java/com/coniv/mait/domain/admin/repository/AnalyticsFeatureRepository.java
@@ -1,0 +1,12 @@
+package com.coniv.mait.domain.admin.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
+
+public interface AnalyticsFeatureRepository extends JpaRepository<AnalyticsFeatureEntity, Long> {
+
+	Optional<AnalyticsFeatureEntity> findByFeatureKey(String featureKey);
+}

--- a/src/main/java/com/coniv/mait/domain/admin/service/AnalyticsEventCollectService.java
+++ b/src/main/java/com/coniv/mait/domain/admin/service/AnalyticsEventCollectService.java
@@ -6,8 +6,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
 import com.coniv.mait.domain.admin.repository.AnalyticsEventRepository;
+import com.coniv.mait.domain.admin.repository.AnalyticsFeatureRepository;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -15,24 +18,30 @@ import lombok.RequiredArgsConstructor;
 public class AnalyticsEventCollectService {
 
 	private final AnalyticsEventRepository analyticsEventRepository;
+	private final AnalyticsFeatureRepository analyticsFeatureRepository;
 
 	/**
 	 * 분석 이벤트를 1건 저장한다.
 	 *
-	 * <p>{@code (feature_key, event_name, user_id, session_id)} 조합이 이미 존재하면 저장하지 않는다(keep-first).
+	 * <p>{@code feature_key}는 미리 등록된 feature 마스터를 참조한다. 등록되지 않은 feature_key면 {@link EntityNotFoundException}을 던진다.
+	 *
+	 * <p>{@code (feature_id, event_name, user_id, session_id)} 조합이 이미 존재하면 저장하지 않는다(keep-first).
 	 * 재전송/중복 전송을 멱등하게 무시하며, DB의 UNIQUE 제약이 동시성 backstop 역할을 한다.
 	 */
 	@Transactional
 	public void collect(final Long userId, final String featureKey, final String eventName,
 		final String sessionId, final Integer step, final String metadata) {
-		boolean exists = analyticsEventRepository.existsByFeatureKeyAndEventNameAndUserIdAndSessionId(
-			featureKey, eventName, userId, sessionId);
+		AnalyticsFeatureEntity feature = analyticsFeatureRepository.findByFeatureKey(featureKey)
+			.orElseThrow(() -> new EntityNotFoundException("등록되지 않은 기능(feature)입니다: " + featureKey));
+
+		boolean exists = analyticsEventRepository.existsByFeatureAndEventNameAndUserIdAndSessionId(
+			feature, eventName, userId, sessionId);
 		if (exists) {
 			return;
 		}
 
 		analyticsEventRepository.save(AnalyticsEventEntity.builder()
-			.featureKey(featureKey)
+			.feature(feature)
 			.eventName(eventName)
 			.userId(userId)
 			.sessionId(sessionId)

--- a/src/main/java/com/coniv/mait/domain/admin/service/AnalyticsEventQueryService.java
+++ b/src/main/java/com/coniv/mait/domain/admin/service/AnalyticsEventQueryService.java
@@ -1,0 +1,36 @@
+package com.coniv.mait.domain.admin.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
+import com.coniv.mait.domain.admin.repository.AnalyticsEventRepository;
+import com.coniv.mait.domain.admin.repository.AnalyticsFeatureRepository;
+import com.coniv.mait.domain.admin.service.dto.AnalyticsEventStatsDto;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalyticsEventQueryService {
+
+	private final AnalyticsFeatureRepository analyticsFeatureRepository;
+	private final AnalyticsEventRepository analyticsEventRepository;
+
+	public List<AnalyticsFeatureEntity> getFeatures() {
+		return analyticsFeatureRepository.findAll();
+	}
+
+	public AnalyticsEventStatsDto getEventStats(final Long featureId) {
+		AnalyticsFeatureEntity feature = analyticsFeatureRepository.findById(featureId)
+			.orElseThrow(() -> new EntityNotFoundException("등록되지 않은 기능(feature)입니다: " + featureId));
+
+		List<AnalyticsEventEntity> events = analyticsEventRepository.findAllByFeature(feature);
+		return AnalyticsEventStatsDto.of(feature.getFeatureKey(), events);
+	}
+}

--- a/src/main/java/com/coniv/mait/domain/admin/service/dto/AnalyticsEventStatsDto.java
+++ b/src/main/java/com/coniv/mait/domain/admin/service/dto/AnalyticsEventStatsDto.java
@@ -1,0 +1,26 @@
+package com.coniv.mait.domain.admin.service.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
+
+public record AnalyticsEventStatsDto(String featureKey, List<AnalyticsEventStepCountDto> stepCounts) {
+
+	public static AnalyticsEventStatsDto of(final String featureKey, final List<AnalyticsEventEntity> events) {
+		Map<String, Map<Integer, Long>> countByEventNameAndStep = new TreeMap<>();
+		for (AnalyticsEventEntity event : events) {
+			countByEventNameAndStep
+				.computeIfAbsent(event.getEventName(), key -> new TreeMap<>())
+				.merge(event.getStep(), 1L, Long::sum);
+		}
+
+		List<AnalyticsEventStepCountDto> stepCounts = new ArrayList<>();
+		countByEventNameAndStep.forEach((eventName, countByStep) ->
+			countByStep.forEach((step, count) ->
+				stepCounts.add(new AnalyticsEventStepCountDto(eventName, step, count))));
+		return new AnalyticsEventStatsDto(featureKey, stepCounts);
+	}
+}

--- a/src/main/java/com/coniv/mait/domain/admin/service/dto/AnalyticsEventStepCountDto.java
+++ b/src/main/java/com/coniv/mait/domain/admin/service/dto/AnalyticsEventStepCountDto.java
@@ -1,0 +1,4 @@
+package com.coniv.mait.domain.admin.service.dto;
+
+public record AnalyticsEventStepCountDto(String eventName, int step, long count) {
+}

--- a/src/main/java/com/coniv/mait/web/admin/controller/AnalyticsAdminController.java
+++ b/src/main/java/com/coniv/mait/web/admin/controller/AnalyticsAdminController.java
@@ -1,0 +1,46 @@
+package com.coniv.mait.web.admin.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coniv.mait.domain.admin.service.AnalyticsEventQueryService;
+import com.coniv.mait.global.response.ApiResponse;
+import com.coniv.mait.web.admin.dto.AnalyticsEventStatsApiResponse;
+import com.coniv.mait.web.admin.dto.AnalyticsFeatureApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "분석 이벤트 조회 어드민 API")
+@RestController
+@RequestMapping("/api/v1/admin/analytics")
+@RequiredArgsConstructor
+public class AnalyticsAdminController {
+
+	private final AnalyticsEventQueryService analyticsEventQueryService;
+
+	@Operation(summary = "분석 feature 목록 조회", description = "이벤트가 수집되는 분석 feature 마스터 전체를 조회한다.")
+	@GetMapping("/features")
+	public ResponseEntity<ApiResponse<List<AnalyticsFeatureApiResponse>>> getFeatures() {
+		List<AnalyticsFeatureApiResponse> features = analyticsEventQueryService.getFeatures().stream()
+			.map(AnalyticsFeatureApiResponse::from)
+			.toList();
+		return ResponseEntity.ok(ApiResponse.ok(features));
+	}
+
+	@Operation(summary = "feature별 이벤트 통계 조회",
+		description = "feature 1건에 대해 (event_name, step) 단위로 발생 수를 집계한다. "
+			+ "event_name별로 묶어 총 발생 수와 step 분포를 함께 반환한다.")
+	@GetMapping("/features/{featureId}/event-stats")
+	public ResponseEntity<ApiResponse<AnalyticsEventStatsApiResponse>> getEventStats(
+		@PathVariable final Long featureId) {
+		return ResponseEntity.ok(ApiResponse.ok(
+			AnalyticsEventStatsApiResponse.from(analyticsEventQueryService.getEventStats(featureId))));
+	}
+}

--- a/src/main/java/com/coniv/mait/web/admin/dto/AnalyticsEventStatsApiResponse.java
+++ b/src/main/java/com/coniv/mait/web/admin/dto/AnalyticsEventStatsApiResponse.java
@@ -1,0 +1,65 @@
+package com.coniv.mait.web.admin.dto;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.coniv.mait.domain.admin.service.dto.AnalyticsEventStatsDto;
+import com.coniv.mait.domain.admin.service.dto.AnalyticsEventStepCountDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "feature별 이벤트 통계 응답. event_name별 발생 수와 step 분포를 담는다.")
+public record AnalyticsEventStatsApiResponse(
+	@Schema(description = "feature 식별 키", example = "onboarding", requiredMode = Schema.RequiredMode.REQUIRED)
+	String featureKey,
+
+	@Schema(description = "전체 이벤트 발생 수", requiredMode = Schema.RequiredMode.REQUIRED)
+	long totalCount,
+
+	@Schema(description = "event_name별 통계 목록 (event_name 오름차순)", requiredMode = Schema.RequiredMode.REQUIRED)
+	List<EventStat> events
+) {
+	public static AnalyticsEventStatsApiResponse from(final AnalyticsEventStatsDto stats) {
+		Map<String, List<StepCount>> stepsByEvent = new LinkedHashMap<>();
+		long totalCount = 0;
+		for (AnalyticsEventStepCountDto row : stats.stepCounts()) {
+			stepsByEvent.computeIfAbsent(row.eventName(), key -> new ArrayList<>())
+				.add(new StepCount(row.step(), row.count()));
+			totalCount += row.count();
+		}
+
+		List<EventStat> events = stepsByEvent.entrySet().stream()
+			.map(entry -> new EventStat(
+				entry.getKey(),
+				entry.getValue().stream().mapToLong(StepCount::count).sum(),
+				entry.getValue()))
+			.toList();
+
+		return new AnalyticsEventStatsApiResponse(stats.featureKey(), totalCount, events);
+	}
+
+	@Schema(description = "단일 event_name에 대한 통계")
+	public record EventStat(
+		@Schema(description = "이벤트 이름", example = "player_set_list_exit", requiredMode = Schema.RequiredMode.REQUIRED)
+		String eventName,
+
+		@Schema(description = "해당 이벤트 총 발생 수", requiredMode = Schema.RequiredMode.REQUIRED)
+		long count,
+
+		@Schema(description = "step별 발생 수 분포 (step 오름차순)", requiredMode = Schema.RequiredMode.REQUIRED)
+		List<StepCount> steps
+	) {
+	}
+
+	@Schema(description = "특정 step의 발생 수")
+	public record StepCount(
+		@Schema(description = "step 값", requiredMode = Schema.RequiredMode.REQUIRED)
+		int step,
+
+		@Schema(description = "해당 step 발생 수", requiredMode = Schema.RequiredMode.REQUIRED)
+		long count
+	) {
+	}
+}

--- a/src/main/java/com/coniv/mait/web/admin/dto/AnalyticsFeatureApiResponse.java
+++ b/src/main/java/com/coniv/mait/web/admin/dto/AnalyticsFeatureApiResponse.java
@@ -1,0 +1,22 @@
+package com.coniv.mait.web.admin.dto;
+
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record AnalyticsFeatureApiResponse(
+	@Schema(description = "feature PK", requiredMode = Schema.RequiredMode.REQUIRED)
+	Long id,
+
+	@Schema(description = "feature 식별 키", example = "onboarding", requiredMode = Schema.RequiredMode.REQUIRED)
+	String featureKey
+) {
+	public static AnalyticsFeatureApiResponse from(final AnalyticsFeatureEntity feature) {
+		return AnalyticsFeatureApiResponse.builder()
+			.id(feature.getId())
+			.featureKey(feature.getFeatureKey())
+			.build();
+	}
+}

--- a/src/test/java/com/coniv/mait/domain/admin/service/AnalyticsEventCollectServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/admin/service/AnalyticsEventCollectServiceTest.java
@@ -3,6 +3,8 @@ package com.coniv.mait.domain.admin.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +14,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
 import com.coniv.mait.domain.admin.repository.AnalyticsEventRepository;
+import com.coniv.mait.domain.admin.repository.AnalyticsFeatureRepository;
+
+import jakarta.persistence.EntityNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
 class AnalyticsEventCollectServiceTest {
@@ -28,12 +34,17 @@ class AnalyticsEventCollectServiceTest {
 	@Mock
 	private AnalyticsEventRepository analyticsEventRepository;
 
+	@Mock
+	private AnalyticsFeatureRepository analyticsFeatureRepository;
+
 	@Test
 	@DisplayName("동일 조합이 존재하지 않으면 이벤트를 저장한다")
 	void collect_savesWhenNotDuplicate() {
 		// given
-		given(analyticsEventRepository.existsByFeatureKeyAndEventNameAndUserIdAndSessionId(
-			FEATURE_KEY, EVENT_NAME, USER_ID, SESSION_ID)).willReturn(false);
+		AnalyticsFeatureEntity feature = AnalyticsFeatureEntity.of(FEATURE_KEY);
+		given(analyticsFeatureRepository.findByFeatureKey(FEATURE_KEY)).willReturn(Optional.of(feature));
+		given(analyticsEventRepository.existsByFeatureAndEventNameAndUserIdAndSessionId(
+			feature, EVENT_NAME, USER_ID, SESSION_ID)).willReturn(false);
 
 		// when
 		analyticsEventCollectService.collect(USER_ID, FEATURE_KEY, EVENT_NAME, SESSION_ID, 2, "context");
@@ -42,7 +53,7 @@ class AnalyticsEventCollectServiceTest {
 		ArgumentCaptor<AnalyticsEventEntity> captor = ArgumentCaptor.forClass(AnalyticsEventEntity.class);
 		then(analyticsEventRepository).should().save(captor.capture());
 		AnalyticsEventEntity saved = captor.getValue();
-		assertThat(saved.getFeatureKey()).isEqualTo(FEATURE_KEY);
+		assertThat(saved.getFeature()).isEqualTo(feature);
 		assertThat(saved.getEventName()).isEqualTo(EVENT_NAME);
 		assertThat(saved.getUserId()).isEqualTo(USER_ID);
 		assertThat(saved.getSessionId()).isEqualTo(SESSION_ID);
@@ -55,8 +66,10 @@ class AnalyticsEventCollectServiceTest {
 	@DisplayName("동일 조합이 이미 존재하면 저장하지 않는다")
 	void collect_skipsWhenDuplicate() {
 		// given
-		given(analyticsEventRepository.existsByFeatureKeyAndEventNameAndUserIdAndSessionId(
-			FEATURE_KEY, EVENT_NAME, USER_ID, SESSION_ID)).willReturn(true);
+		AnalyticsFeatureEntity feature = AnalyticsFeatureEntity.of(FEATURE_KEY);
+		given(analyticsFeatureRepository.findByFeatureKey(FEATURE_KEY)).willReturn(Optional.of(feature));
+		given(analyticsEventRepository.existsByFeatureAndEventNameAndUserIdAndSessionId(
+			feature, EVENT_NAME, USER_ID, SESSION_ID)).willReturn(true);
 
 		// when
 		analyticsEventCollectService.collect(USER_ID, FEATURE_KEY, EVENT_NAME, SESSION_ID, 2, null);
@@ -69,8 +82,10 @@ class AnalyticsEventCollectServiceTest {
 	@DisplayName("step 이 null 이면 0 으로 저장한다")
 	void collect_defaultsStepToZeroWhenNull() {
 		// given
-		given(analyticsEventRepository.existsByFeatureKeyAndEventNameAndUserIdAndSessionId(
-			FEATURE_KEY, EVENT_NAME, USER_ID, SESSION_ID)).willReturn(false);
+		AnalyticsFeatureEntity feature = AnalyticsFeatureEntity.of(FEATURE_KEY);
+		given(analyticsFeatureRepository.findByFeatureKey(FEATURE_KEY)).willReturn(Optional.of(feature));
+		given(analyticsEventRepository.existsByFeatureAndEventNameAndUserIdAndSessionId(
+			feature, EVENT_NAME, USER_ID, SESSION_ID)).willReturn(false);
 
 		// when
 		analyticsEventCollectService.collect(USER_ID, FEATURE_KEY, EVENT_NAME, SESSION_ID, null, null);
@@ -79,5 +94,18 @@ class AnalyticsEventCollectServiceTest {
 		ArgumentCaptor<AnalyticsEventEntity> captor = ArgumentCaptor.forClass(AnalyticsEventEntity.class);
 		then(analyticsEventRepository).should().save(captor.capture());
 		assertThat(captor.getValue().getStep()).isZero();
+	}
+
+	@Test
+	@DisplayName("등록되지 않은 feature_key 면 EntityNotFoundException 을 던진다")
+	void collect_throwsWhenFeatureNotRegistered() {
+		// given
+		given(analyticsFeatureRepository.findByFeatureKey(FEATURE_KEY)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() ->
+			analyticsEventCollectService.collect(USER_ID, FEATURE_KEY, EVENT_NAME, SESSION_ID, 2, null))
+			.isInstanceOf(EntityNotFoundException.class);
+		then(analyticsEventRepository).should(never()).save(any());
 	}
 }

--- a/src/test/java/com/coniv/mait/domain/admin/service/AnalyticsEventQueryServiceTest.java
+++ b/src/test/java/com/coniv/mait/domain/admin/service/AnalyticsEventQueryServiceTest.java
@@ -1,0 +1,98 @@
+package com.coniv.mait.domain.admin.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
+import com.coniv.mait.domain.admin.repository.AnalyticsEventRepository;
+import com.coniv.mait.domain.admin.repository.AnalyticsFeatureRepository;
+import com.coniv.mait.domain.admin.service.dto.AnalyticsEventStatsDto;
+import com.coniv.mait.domain.admin.service.dto.AnalyticsEventStepCountDto;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsEventQueryServiceTest {
+
+	private static final Long FEATURE_ID = 1L;
+	private static final String FEATURE_KEY = "onboarding";
+
+	@InjectMocks
+	private AnalyticsEventQueryService analyticsEventQueryService;
+
+	@Mock
+	private AnalyticsFeatureRepository analyticsFeatureRepository;
+
+	@Mock
+	private AnalyticsEventRepository analyticsEventRepository;
+
+	@Test
+	@DisplayName("등록된 feature 마스터 전체를 조회한다")
+	void getFeatures_returnsAllFeatures() {
+		// given
+		AnalyticsFeatureEntity onboarding = AnalyticsFeatureEntity.of("onboarding");
+		AnalyticsFeatureEntity solving = AnalyticsFeatureEntity.of("solving");
+		given(analyticsFeatureRepository.findAll()).willReturn(List.of(onboarding, solving));
+
+		// when
+		List<AnalyticsFeatureEntity> result = analyticsEventQueryService.getFeatures();
+
+		// then
+		assertThat(result).containsExactly(onboarding, solving);
+	}
+
+	@Test
+	@DisplayName("이벤트를 (event_name, step) 단위로 집계하며 event_name·step 오름차순으로 정렬한다")
+	void getEventStats_aggregatesByEventNameAndStep() {
+		// given
+		AnalyticsFeatureEntity feature = AnalyticsFeatureEntity.of(FEATURE_KEY);
+		given(analyticsFeatureRepository.findById(FEATURE_ID)).willReturn(Optional.of(feature));
+		given(analyticsEventRepository.findAllByFeature(feature)).willReturn(List.of(
+			event(feature, "player_set_list_view", 0),
+			event(feature, "player_set_list_view", 0),
+			event(feature, "player_set_list_exit", 3),
+			event(feature, "player_set_list_exit", 3),
+			event(feature, "player_set_list_exit", 1)));
+
+		// when
+		AnalyticsEventStatsDto result = analyticsEventQueryService.getEventStats(FEATURE_ID);
+
+		// then
+		assertThat(result.featureKey()).isEqualTo(FEATURE_KEY);
+		assertThat(result.stepCounts()).containsExactly(
+			new AnalyticsEventStepCountDto("player_set_list_exit", 1, 1),
+			new AnalyticsEventStepCountDto("player_set_list_exit", 3, 2),
+			new AnalyticsEventStepCountDto("player_set_list_view", 0, 2));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 featureId 면 EntityNotFoundException 을 던진다")
+	void getEventStats_throwsWhenFeatureNotFound() {
+		// given
+		given(analyticsFeatureRepository.findById(FEATURE_ID)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> analyticsEventQueryService.getEventStats(FEATURE_ID))
+			.isInstanceOf(EntityNotFoundException.class);
+		then(analyticsEventRepository).should(never()).findAllByFeature(any());
+	}
+
+	private AnalyticsEventEntity event(final AnalyticsFeatureEntity feature, final String eventName, final int step) {
+		return AnalyticsEventEntity.builder()
+			.feature(feature)
+			.eventName(eventName)
+			.step(step)
+			.build();
+	}
+}

--- a/src/test/java/com/coniv/mait/web/admin/controller/AnalyticsAdminControllerTest.java
+++ b/src/test/java/com/coniv/mait/web/admin/controller/AnalyticsAdminControllerTest.java
@@ -1,0 +1,91 @@
+package com.coniv.mait.web.admin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
+import com.coniv.mait.domain.admin.service.AnalyticsEventQueryService;
+import com.coniv.mait.domain.admin.service.dto.AnalyticsEventStatsDto;
+import com.coniv.mait.domain.admin.service.dto.AnalyticsEventStepCountDto;
+import com.coniv.mait.global.filter.JwtAuthorizationFilter;
+import com.coniv.mait.login.WithCustomUser;
+import com.coniv.mait.web.integration.BaseIntegrationTest;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+@WithCustomUser
+public class AnalyticsAdminControllerTest extends BaseIntegrationTest {
+
+	@MockitoBean
+	private AnalyticsEventQueryService analyticsEventQueryService;
+
+	@MockitoBean
+	private JwtAuthorizationFilter jwtAuthorizationFilter;
+
+	@BeforeEach
+	void passThroughJwtFilter() throws Exception {
+		Mockito.doAnswer(inv -> {
+			ServletRequest request = inv.getArgument(0);
+			ServletResponse response = inv.getArgument(1);
+			FilterChain chain = inv.getArgument(2);
+			chain.doFilter(request, response);
+			return null;
+		}).when(jwtAuthorizationFilter).doFilter(Mockito.any(), Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	@DisplayName("분석 feature 목록 조회에 성공한다")
+	void getFeatures_success() throws Exception {
+		// given
+		BDDMockito.given(analyticsEventQueryService.getFeatures()).willReturn(List.of(
+			AnalyticsFeatureEntity.builder().id(1L).featureKey("onboarding").build()));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/admin/analytics/features"))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.isSuccess").value(true),
+				jsonPath("$.data[0].id").value(1),
+				jsonPath("$.data[0].featureKey").value("onboarding"));
+	}
+
+	@Test
+	@DisplayName("feature별 이벤트 통계 조회에 성공한다")
+	void getEventStats_success() throws Exception {
+		// given
+		BDDMockito.given(analyticsEventQueryService.getEventStats(1L)).willReturn(
+			new AnalyticsEventStatsDto("onboarding", List.of(
+				new AnalyticsEventStepCountDto("player_set_list_exit", 1, 1),
+				new AnalyticsEventStepCountDto("player_set_list_exit", 3, 2),
+				new AnalyticsEventStepCountDto("player_set_list_view", 0, 2))));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/admin/analytics/features/1/event-stats"))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.isSuccess").value(true),
+				jsonPath("$.data.featureKey").value("onboarding"),
+				jsonPath("$.data.totalCount").value(5),
+				jsonPath("$.data.events[0].eventName").value("player_set_list_exit"),
+				jsonPath("$.data.events[0].count").value(3),
+				jsonPath("$.data.events[0].steps[0].step").value(1),
+				jsonPath("$.data.events[0].steps[0].count").value(1),
+				jsonPath("$.data.events[0].steps[1].step").value(3),
+				jsonPath("$.data.events[0].steps[1].count").value(2),
+				jsonPath("$.data.events[1].eventName").value("player_set_list_view"),
+				jsonPath("$.data.events[1].count").value(2),
+				jsonPath("$.data.events[1].steps[0].step").value(0),
+				jsonPath("$.data.events[1].steps[0].count").value(2));
+	}
+}

--- a/src/test/java/com/coniv/mait/web/admin/controller/AnalyticsAdminIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/admin/controller/AnalyticsAdminIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.coniv.mait.web.admin.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
+import com.coniv.mait.domain.admin.repository.AnalyticsEventRepository;
+import com.coniv.mait.domain.admin.repository.AnalyticsFeatureRepository;
+import com.coniv.mait.global.filter.JwtAuthorizationFilter;
+import com.coniv.mait.login.WithCustomUser;
+import com.coniv.mait.web.integration.BaseIntegrationTest;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+@WithCustomUser
+public class AnalyticsAdminIntegrationTest extends BaseIntegrationTest {
+
+	private static final String SESSION_A = "550e8400-e29b-41d4-a716-446655440000";
+	private static final String SESSION_B = "550e8400-e29b-41d4-a716-446655440001";
+
+	@Autowired
+	private AnalyticsEventRepository analyticsEventRepository;
+
+	@Autowired
+	private AnalyticsFeatureRepository analyticsFeatureRepository;
+
+	@MockitoBean
+	private JwtAuthorizationFilter jwtAuthorizationFilter;
+
+	private AnalyticsFeatureEntity onboarding;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		analyticsEventRepository.deleteAll();
+		analyticsFeatureRepository.deleteAll();
+		onboarding = analyticsFeatureRepository.save(AnalyticsFeatureEntity.of("onboarding"));
+
+		saveEvent("player_set_list_view", 1L, SESSION_A, 0);
+		saveEvent("player_set_list_view", 2L, SESSION_B, 0);
+		saveEvent("player_set_list_exit", 1L, SESSION_A, 3);
+		saveEvent("player_set_list_exit", 2L, SESSION_B, 1);
+
+		Mockito.doAnswer(inv -> {
+			ServletRequest request = inv.getArgument(0);
+			ServletResponse response = inv.getArgument(1);
+			FilterChain chain = inv.getArgument(2);
+			chain.doFilter(request, response);
+			return null;
+		}).when(jwtAuthorizationFilter).doFilter(Mockito.any(), Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	@DisplayName("등록된 feature 목록을 조회한다")
+	void getFeatures_returnsRegisteredFeatures() throws Exception {
+		mockMvc.perform(get("/api/v1/admin/analytics/features"))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.isSuccess").value(true),
+				jsonPath("$.data.length()").value(1),
+				jsonPath("$.data[0].id").value(onboarding.getId()),
+				jsonPath("$.data[0].featureKey").value("onboarding"));
+	}
+
+	@Test
+	@DisplayName("feature에 저장된 이벤트를 (event_name, step) 단위로 집계해 응답한다")
+	void getEventStats_aggregatesPersistedEvents() throws Exception {
+		mockMvc.perform(get("/api/v1/admin/analytics/features/{featureId}/event-stats", onboarding.getId()))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.isSuccess").value(true),
+				jsonPath("$.data.featureKey").value("onboarding"),
+				jsonPath("$.data.totalCount").value(4),
+				jsonPath("$.data.events[0].eventName").value("player_set_list_exit"),
+				jsonPath("$.data.events[0].count").value(2),
+				jsonPath("$.data.events[0].steps[0].step").value(1),
+				jsonPath("$.data.events[0].steps[0].count").value(1),
+				jsonPath("$.data.events[0].steps[1].step").value(3),
+				jsonPath("$.data.events[0].steps[1].count").value(1),
+				jsonPath("$.data.events[1].eventName").value("player_set_list_view"),
+				jsonPath("$.data.events[1].count").value(2),
+				jsonPath("$.data.events[1].steps[0].step").value(0),
+				jsonPath("$.data.events[1].steps[0].count").value(2));
+	}
+
+	private void saveEvent(final String eventName, final Long userId, final String sessionId, final int step) {
+		analyticsEventRepository.save(AnalyticsEventEntity.builder()
+			.feature(onboarding)
+			.eventName(eventName)
+			.userId(userId)
+			.sessionId(sessionId)
+			.step(step)
+			.occurredAt(LocalDateTime.now())
+			.build());
+	}
+}

--- a/src/test/java/com/coniv/mait/web/admin/controller/AnalyticsEventIntegrationTest.java
+++ b/src/test/java/com/coniv/mait/web/admin/controller/AnalyticsEventIntegrationTest.java
@@ -15,7 +15,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.coniv.mait.domain.admin.entity.AnalyticsEventEntity;
+import com.coniv.mait.domain.admin.entity.AnalyticsFeatureEntity;
 import com.coniv.mait.domain.admin.repository.AnalyticsEventRepository;
+import com.coniv.mait.domain.admin.repository.AnalyticsFeatureRepository;
 import com.coniv.mait.domain.user.entity.UserEntity;
 import com.coniv.mait.domain.user.repository.UserEntityRepository;
 import com.coniv.mait.global.filter.JwtAuthorizationFilter;
@@ -35,6 +37,9 @@ public class AnalyticsEventIntegrationTest extends BaseIntegrationTest {
 	private AnalyticsEventRepository analyticsEventRepository;
 
 	@Autowired
+	private AnalyticsFeatureRepository analyticsFeatureRepository;
+
+	@Autowired
 	private UserEntityRepository userEntityRepository;
 
 	@MockitoBean
@@ -43,6 +48,8 @@ public class AnalyticsEventIntegrationTest extends BaseIntegrationTest {
 	@BeforeEach
 	void setUp() throws Exception {
 		analyticsEventRepository.deleteAll();
+		analyticsFeatureRepository.deleteAll();
+		analyticsFeatureRepository.save(AnalyticsFeatureEntity.of("onboarding"));
 		Mockito.doAnswer(inv -> {
 			ServletRequest request = inv.getArgument(0);
 			ServletResponse response = inv.getArgument(1);
@@ -78,7 +85,7 @@ public class AnalyticsEventIntegrationTest extends BaseIntegrationTest {
 		assertThat(events).hasSize(1);
 		AnalyticsEventEntity saved = events.get(0);
 		assertThat(saved.getUserId()).isEqualTo(user.getId());
-		assertThat(saved.getFeatureKey()).isEqualTo("onboarding");
+		assertThat(saved.getFeature().getFeatureKey()).isEqualTo("onboarding");
 		assertThat(saved.getEventName()).isEqualTo("player_set_list_view");
 		assertThat(saved.getSessionId()).isEqualTo(SESSION_ID);
 		assertThat(saved.getStep()).isEqualTo(2);


### PR DESCRIPTION
- AnalyticsFeatureEntity(analytics_feature) 신설, feature_key UNIQUE
- AnalyticsEventEntity의 feature_key 컬럼을 feature_id FK로 변경
- 수집 시 미등록 feature_key는 EntityNotFoundException 처리(사전 등록 전제)

### Motivation

<!-- 이 PR이 해결하려는 내용을 적어주세요. -->

### Modification

<!-- 이 PR이 추가/변경 하는 내용에 대해서 최대한 자세히 작성해주세요 -->
<!-- 어떻게 문제를 해결할 것인지? -->

### Result

<!-- 이 PR 머지된 이후에 발생할 일들에 대해서 작성해주세요 -->
<!-- resolve jira issue link를 적어주세요 -->

### Test (option)

<!-- 테스트 결과를 보여주세요. -->

- [ ] 단위테스트를 작성했는지
- [ ] 컨트롤러 단위테스트를 작성했는지
- [ ] 통합테스트를 작성했는지

### SQL

<!-- 해당 PR을 통해 변경될 DB Schema에 대한 DDL 등의 쿼리를 적어주세요. -->

```sql
-- 1) 신규 테이블: feature 마스터
CREATE TABLE analytics_feature (
    id          BIGINT       NOT NULL AUTO_INCREMENT,
    feature_key VARCHAR(100) NOT NULL,
    created_at  DATETIME(6)  NOT NULL,
    modified_at DATETIME(6)  NOT NULL,
    PRIMARY KEY (id),
    CONSTRAINT uk_analytics_feature_key UNIQUE (feature_key)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

-- 2) 기존 event 데이터의 feature_key 를 마스터로 이관 (DISTINCT)
INSERT INTO analytics_feature (feature_key, created_at, modified_at)
SELECT DISTINCT feature_key, NOW(6), NOW(6)
FROM analytics_event;

-- 3) feature_id 컬럼 추가 (백필 위해 우선 NULL 허용)
ALTER TABLE analytics_event
    ADD COLUMN feature_id BIGINT NULL AFTER id;

-- 4) feature_key 매칭으로 feature_id 백필
UPDATE analytics_event e
JOIN analytics_feature f ON f.feature_key = e.feature_key
SET e.feature_id = f.id;

-- 5) 구 유니크/컬럼 제거 → feature_id NOT NULL + 신규 유니크 + FK
ALTER TABLE analytics_event
    DROP INDEX  uk_analytics_event,
    DROP COLUMN feature_key,
    MODIFY COLUMN feature_id BIGINT NOT NULL,
    ADD CONSTRAINT uk_analytics_event UNIQUE (feature_id, event_name, user_id, session_id),
    ADD CONSTRAINT fk_analytics_event_feature FOREIGN KEY (feature_id) REFERENCES analytics_feature (id);

```
